### PR TITLE
Add support for mocks with generic type parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,19 @@ The untyped callable references using `<T : Any> whenInvoking(T, String)` and
 | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
 | `then(block: (args: Array<Any?>) -> Any?)` | Invokes the specified block. The argument passed to the block is an array of arguments passed to the invocation. |
 
+## Generic Types
+
+When mocking a generic type, the value returned by `<T> mock(KClass<T>)` must be type-cast to the 
+desired type:
+
+```kotlin
+class GenericTypeTest {
+    @Suppress("UNCHECKED_CAST")
+    @Mock
+    val list = mock(List::class) as List<String>
+}
+```
+
 ## Verification
 
 Verification of invocations to mocks is supported through the `verify(mock)` API:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To mock a given method on an interface, annotate a property holding the interfac
 ```kotlin
 class GitHubServiceTests {
     @Mock
-    val api = mock(GitHubAPI::class)
+    val api = mock(classOf<GitHubAPI>())
 }
 ```
 
@@ -167,14 +167,13 @@ The untyped callable references using `<T : Any> whenInvoking(T, String)` and
 
 ## Generic Types
 
-When mocking a generic type, the value returned by `<T> mock(KClass<T>)` must be type-cast to the 
-desired type:
+When mocking a generic type, use the `<T> classOf(): KClass<T>` function to retain the type 
+arguments when passed to the `<T> mock(KClass<T>)` function.
 
 ```kotlin
 class GenericTypeTest {
-    @Suppress("UNCHECKED_CAST")
     @Mock
-    val list = mock(List::class) as List<String>
+    val list = mock(classOf<List<String>>())
 }
 ```
 

--- a/mockative-processor/src/main/kotlin/io/mockative/FunctionWriter.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/FunctionWriter.kt
@@ -29,6 +29,15 @@ class FunctionWriter(private val writer: Writer) {
 
     private fun appendStandardSyntax(function: MockDescriptor.Function) {
         writer.append(" fun ")
+
+        val typeParameters = function.typeParameters
+        if (typeParameters.isNotEmpty()) {
+            writer.append('<')
+            writer.append(typeParameters.joinToString(", ") { it.name })
+            writer.append('>')
+            writer.append(' ')
+        }
+
         writer.append(function.name)
     }
 

--- a/mockative-processor/src/main/kotlin/io/mockative/MockDescriptor.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/MockDescriptor.kt
@@ -13,6 +13,7 @@ data class MockDescriptor(
     val name: String,
     val qualifiedName: String,
     val visibility: String?,
+    val typeParameters: List<TypeParameter>,
 
     val mockName: String,
 
@@ -37,13 +38,13 @@ data class MockDescriptor(
             val name: String,
             val type: String
         )
-
-        data class TypeParameter(
-            val name: String,
-            val variance: String,
-            val bounds: List<String>
-        )
     }
+
+    data class TypeParameter(
+        val name: String,
+        val variance: String,
+        val bounds: List<String>
+    )
 }
 
 fun createMockDescriptor(declaration: KSClassDeclaration): MockDescriptor {
@@ -60,6 +61,9 @@ fun createMockDescriptor(declaration: KSClassDeclaration): MockDescriptor {
         modifiers.contains(Modifier.PUBLIC) -> null
         else -> null
     }
+
+    val typeParameters = declaration.typeParameters
+        .map { createTypeParameter(it) }
 
     val mockName = "${name}Mock"
 
@@ -78,6 +82,7 @@ fun createMockDescriptor(declaration: KSClassDeclaration): MockDescriptor {
         name = name,
         qualifiedName = qualifiedName,
         visibility = visibility,
+        typeParameters = typeParameters,
         mockName = mockName,
         properties = properties,
         functions = functions
@@ -112,14 +117,14 @@ fun createFunction(declaration: KSFunctionDeclaration): MockDescriptor.Function 
     )
 }
 
-fun createTypeParameter(declaration: KSTypeParameter): MockDescriptor.Function.TypeParameter {
+fun createTypeParameter(declaration: KSTypeParameter): MockDescriptor.TypeParameter {
     val name = declaration.name.asString()
     val variance = declaration.variance.label
     val bounds = declaration.bounds
         .map { bound -> bound.resolveUsageSyntax() }
         .toList()
 
-    return MockDescriptor.Function.TypeParameter(name = name, variance = variance, bounds = bounds)
+    return MockDescriptor.TypeParameter(name = name, variance = variance, bounds = bounds)
 }
 
 fun createParameter(declaration: KSValueParameter): MockDescriptor.Function.Parameter {

--- a/mockative-processor/src/main/kotlin/io/mockative/MockWriter.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/MockWriter.kt
@@ -9,6 +9,7 @@ class MockWriter(private val writer: Writer) {
         writer.appendLine()
 
         appendDeclaration(mock)
+        appendGenericConstraints(mock)
 
         writer.append(" {")
         writer.appendLine()
@@ -18,6 +19,17 @@ class MockWriter(private val writer: Writer) {
         appendFunctions(mock)
 
         writer.append('}')
+    }
+
+    private fun appendGenericConstraints(mock: MockDescriptor) {
+        val genericConstraints = mock.typeParameters
+            .flatMap { typeParameter -> typeParameter.bounds.map { bound -> typeParameter to bound } }
+            .joinToString(", ") { (typeParameter, bound) -> "${typeParameter.name} : $bound" }
+
+        if (genericConstraints.isNotEmpty()) {
+            writer.append(" where ")
+            writer.append(genericConstraints)
+        }
     }
 
     private fun appendPackage(mock: MockDescriptor) {
@@ -33,10 +45,24 @@ class MockWriter(private val writer: Writer) {
 
         writer.append("class ")
         writer.append(mock.mockName)
+
+        val typeParameters = mock.typeParameters
+        if (typeParameters.isNotEmpty()) {
+            writer.append('<')
+            writer.append(typeParameters.joinToString(", ") { it.name })
+            writer.append('>')
+        }
+
         writer.append(" : ")
         writer.append(MockativeTypes.Mockable.name)
         writer.append("(), ")
         writer.append(mock.qualifiedName)
+
+        if (typeParameters.isNotEmpty()) {
+            writer.append('<')
+            writer.append(typeParameters.joinToString(", ") { it.name })
+            writer.append('>')
+        }
     }
 
     private fun appendProperties(mock: MockDescriptor) {

--- a/mockative-processor/src/main/kotlin/io/mockative/MockativeSymbolProcessor.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/MockativeSymbolProcessor.kt
@@ -67,9 +67,26 @@ class MockativeSymbolProcessor(
             mocksWriter.appendLine("package io.mockative")
             mocksWriter.appendLine()
 
-            mocks.forEach {
-                val typeName = it.qualifiedName!!.asString()
-                mocksWriter.appendLine("internal fun mock(@Suppress(\"UNUSED_PARAMETER\") type: kotlin.reflect.KClass<$typeName>): $typeName = ${typeName}Mock()")
+            mocks.forEach { mock ->
+                val className = mock.qualifiedName!!.asString()
+
+                val typeParameters = if (mock.typeParameters.isNotEmpty()) {
+                    "<${mock.typeParameters.joinToString(", "){ it.bounds.firstOrNull()?.resolveUsageSyntax() ?: "Any?" }}>"
+                } else {
+                    ""
+                }
+
+                val wildcardTypeParameters = if (mock.typeParameters.isNotEmpty()) {
+                    "<${mock.typeParameters.joinToString(", ") { "*" }}>"
+                } else {
+                    ""
+                }
+
+                val kClassName = "$className$wildcardTypeParameters"
+                val typeName = "$className$typeParameters"
+                val mockName = "${className}Mock$typeParameters"
+
+                mocksWriter.appendLine("internal fun mock(@Suppress(\"UNUSED_PARAMETER\") type: kotlin.reflect.KClass<$kClassName>): $typeName = $mockName()")
             }
 
             mocksWriter.flush()

--- a/mockative-processor/src/main/kotlin/io/mockative/ResolveUsageSyntax.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/ResolveUsageSyntax.kt
@@ -1,9 +1,6 @@
 package io.mockative
 
-import com.google.devtools.ksp.symbol.KSCallableReference
-import com.google.devtools.ksp.symbol.KSType
-import com.google.devtools.ksp.symbol.KSTypeReference
-import com.google.devtools.ksp.symbol.KSValueParameter
+import com.google.devtools.ksp.symbol.*
 
 fun KSTypeReference.resolveUsageSyntax(): String {
     return when (val element = element) {
@@ -13,10 +10,15 @@ fun KSTypeReference.resolveUsageSyntax(): String {
 }
 
 private fun KSType.resolveUsageSyntax(): String {
-    val qualifiedName = declaration.qualifiedName!!.asString()
-    val typeArguments = if (arguments.isEmpty()) "" else "<${arguments.joinToString(", ") { it.type!!.resolveUsageSyntax() }}>"
-    val nullability = if (isMarkedNullable) "?" else ""
-    return "$qualifiedName$typeArguments$nullability"
+    return when (val declaration = declaration) {
+        is KSTypeParameter -> declaration.name.asString()
+        else -> {
+            val qualifiedName = declaration.qualifiedName!!.asString()
+            val typeArguments = if (arguments.isEmpty()) "" else "<${arguments.joinToString(", ") { it.type!!.resolveUsageSyntax() }}>"
+            val nullability = if (isMarkedNullable) "?" else ""
+            return "$qualifiedName$typeArguments$nullability"
+        }
+    }
 }
 
 private fun KSCallableReference.resolveUsageSyntax(): String {

--- a/mockative-test/src/main/kotlin/io/mockative/PetService.kt
+++ b/mockative-test/src/main/kotlin/io/mockative/PetService.kt
@@ -1,6 +1,6 @@
 package io.mockative
 
-class PetService(private val pets: PetStore, private val noises: NoiseStore) {
+class PetService(private val pets: PetStore<String>, private val noises: NoiseStore) {
     fun add(pet: Pet) = pets.add(pet)
 
     fun pet(name: String): Pet = pets.pet(name)

--- a/mockative-test/src/main/kotlin/io/mockative/PetStore.kt
+++ b/mockative-test/src/main/kotlin/io/mockative/PetStore.kt
@@ -1,12 +1,14 @@
 package io.mockative
 
-interface PetStore {
+interface PetStore<T : CharSequence> {
     var pets: Map<String, () -> Unit>
     val readOnlyPets: Map<String, () -> Unit>
 
     fun add(pet: Pet)
     fun pet(name: String): Pet
     fun petOrNull(name: String): Pet?
+
+    fun <P : Number> generic(type: T, pet: P): CharSequence
 
     fun clear()
 }

--- a/mockative-test/src/test/kotlin/io/mockative/PetServiceTests.kt
+++ b/mockative-test/src/test/kotlin/io/mockative/PetServiceTests.kt
@@ -4,7 +4,7 @@ import org.junit.Test
 
 class PetServiceTests {
 
-    @Mock val petStore = mock(PetStore::class)
+    @Mock val petStore = mock(PetStore::class) as PetStore<String>
     @Mock val noiseStore = mock(NoiseStore::class)
 
     @Test

--- a/mockative-test/src/test/kotlin/io/mockative/PetServiceTests.kt
+++ b/mockative-test/src/test/kotlin/io/mockative/PetServiceTests.kt
@@ -4,8 +4,8 @@ import org.junit.Test
 
 class PetServiceTests {
 
-    @Mock val petStore = mock(PetStore::class) as PetStore<String>
-    @Mock val noiseStore = mock(NoiseStore::class)
+    @Mock val petStore = mock(classOf<PetStore<String>>())
+    @Mock val noiseStore = mock(classOf<NoiseStore>())
 
     @Test
     fun generatesExpectedPetStoreMock() {

--- a/mockative-test/src/test/resources/io/mockative/GeneratedMocks.kt
+++ b/mockative-test/src/test/resources/io/mockative/GeneratedMocks.kt
@@ -1,4 +1,4 @@
 package io.mockative
 
-internal fun mock(@Suppress("UNUSED_PARAMETER") type: kotlin.reflect.KClass<io.mockative.PetStore<*>>): io.mockative.PetStore<kotlin.CharSequence> = io.mockative.PetStoreMock<kotlin.CharSequence>()
+internal fun <T> mock(@Suppress("UNUSED_PARAMETER") type: kotlin.reflect.KClass<io.mockative.PetStore<T>>): io.mockative.PetStore<T> where T : kotlin.CharSequence = io.mockative.PetStoreMock<T>()
 internal fun mock(@Suppress("UNUSED_PARAMETER") type: kotlin.reflect.KClass<io.mockative.NoiseStore>): io.mockative.NoiseStore = io.mockative.NoiseStoreMock()

--- a/mockative-test/src/test/resources/io/mockative/GeneratedMocks.kt
+++ b/mockative-test/src/test/resources/io/mockative/GeneratedMocks.kt
@@ -1,4 +1,4 @@
 package io.mockative
 
-internal fun mock(@Suppress("UNUSED_PARAMETER") type: kotlin.reflect.KClass<io.mockative.PetStore>): io.mockative.PetStore = io.mockative.PetStoreMock()
+internal fun mock(@Suppress("UNUSED_PARAMETER") type: kotlin.reflect.KClass<io.mockative.PetStore<*>>): io.mockative.PetStore<kotlin.CharSequence> = io.mockative.PetStoreMock<kotlin.CharSequence>()
 internal fun mock(@Suppress("UNUSED_PARAMETER") type: kotlin.reflect.KClass<io.mockative.NoiseStore>): io.mockative.NoiseStore = io.mockative.NoiseStoreMock()

--- a/mockative-test/src/test/resources/io/mockative/PetStoreMock.kt
+++ b/mockative-test/src/test/resources/io/mockative/PetStoreMock.kt
@@ -1,6 +1,6 @@
 package io.mockative
 
-class PetStoreMock : io.mockative.Mockable(), io.mockative.PetStore {
+class PetStoreMock<T> : io.mockative.Mockable(), io.mockative.PetStore<T> where T : kotlin.CharSequence {
     override var pets: kotlin.collections.Map<kotlin.String, kotlin.Function0<kotlin.Unit>>
         get() = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Getter("pets"))
         set(value) = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Setter("pets", value))
@@ -9,6 +9,7 @@ class PetStoreMock : io.mockative.Mockable(), io.mockative.PetStore {
 
     override fun add(pet: io.mockative.Pet): kotlin.Unit = io.mockative.Mockable.invoke<kotlin.Unit>(this, io.mockative.Invocation.Function("add", listOf<Any?>(pet)))
     override fun clear(): kotlin.Unit = io.mockative.Mockable.invoke<kotlin.Unit>(this, io.mockative.Invocation.Function("clear", emptyList<Any?>()))
+    override fun <P> generic(type: T, pet: P): kotlin.CharSequence where P : kotlin.Number = io.mockative.Mockable.invoke<kotlin.CharSequence>(this, io.mockative.Invocation.Function("generic", listOf<Any?>(type, pet)))
     override fun pet(name: kotlin.String): io.mockative.Pet = io.mockative.Mockable.invoke<io.mockative.Pet>(this, io.mockative.Invocation.Function("pet", listOf<Any?>(name)))
     override fun petOrNull(name: kotlin.String): io.mockative.Pet? = io.mockative.Mockable.invoke<io.mockative.Pet?>(this, io.mockative.Invocation.Function("petOrNull", listOf<Any?>(name)))
 }

--- a/mockative/src/commonMain/kotlin/io/mockative/ClassOf.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/ClassOf.kt
@@ -1,0 +1,9 @@
+package io.mockative
+
+import kotlin.reflect.KClass
+
+/**
+ * Returns an instance of [KClass] while retaining the generic type information when passed to a
+ * function accepting an instance of [KClass], allowing that function to use the type arguments.
+ */
+inline fun <reified T : Any> classOf(): KClass<T> = T::class

--- a/shared/src/commonTest/kotlin/io/mockative/GitHubServiceMockTests.kt
+++ b/shared/src/commonTest/kotlin/io/mockative/GitHubServiceMockTests.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertEquals
 
 class GitHubServiceMockTests {
 
-    @Mock private val github = mock(GitHubAPI::class)
+    @Mock val github = mock(GitHubAPI::class)
 
     private val service = GitHubService(github, ApplicationDispatchers.Unconfined)
 


### PR DESCRIPTION
Adds support for mocks with generic type parameters.

### Changes to Symbol Processor

- Adds generic type parameters and bounds to member function generation
- Adds generic type parameters and bounds to mock class generation
- Adds generic type parameters and bounds to **GeneratedMocks.kt** function generation

### Changes to runtime library

- Adds `inline fun <reified T> classOf(): KClass<T>` function to preserve type arguments when constructing mocks