### PR TITLE
Implicit stubbing of members returning `Unit`

### DIFF
--- a/mockative/src/commonMain/kotlin/io/mockative/Errors.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/Errors.kt
@@ -11,7 +11,7 @@ class NoSuchMockError(type: KClass<*>) : MockativeError(
         appendLine(1, "Make sure the property holding the mock is annotated with @Mock:")
         appendLine()
         appendLine(2, "@Mock")
-        appendLine(2, "private val myMock = mock(${type.name}::class)")
+        appendLine(2, "private val myMock = mock(classOf<${type.name}>())")
         appendLine(1, "")
     }
 )
@@ -23,7 +23,7 @@ class ReceiverNotMockedError(receiver: Any) : MockativeError(
         appendLine(1, "Make sure the property holding the mock is annotated with @Mock:")
         appendLine()
         appendLine(2, "@Mock")
-        appendLine(2, "private val myMock = mock(${receiver.getClassName()}::class)")
+        appendLine(2, "private val myMock = mock(classOf<${receiver.getClassName()}>())")
         appendLine(1, "")
     }
 )


### PR DESCRIPTION
Implements implicit stubbing of members returning `Unit` as an experimental opt-in API.

To opt-in to implicit stubbing on a project level, add the following KSP option:

**build.gradle.kts**
```kotlin
ksp {
    arg("mockative.stubsUnitByDefault", "true")
}
```

Alternatively, you can opt-in (or opt-out if you've opted in on the project level), using the 
`configure(mock, block)` function either inline:

```kotlin
@Mock val api = configure(mock(classOf<GitHubAPI>())) { stubsUnitByDefault = true }
```

Or as needed:

```kotlin
@Mock val api = mock(classOf<GitHubAPI>())

@Test
fun test() {
    configure(api) { stubsUnitByDefault = true }
}
```

### Experimental API

The following function was introduced as an experimental API to allow controlling implicit stubbing of members returning `Unit` on a per-mock level:

```kotlin
fun <T : Any> configure(subject: T, block: MockConfiguration.() -> Unit): T
```