### PR TITLE
Implicit stubbing of members returning `Unit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,22 @@
 Mocking for Kotlin/Native and Kotlin Multiplatform using the Kotlin Symbol Processing API ([KSP]).
 Notable features include:
 
-- Effortless multi-threading when using coroutines (
-  see [Coroutines.kt](shared/src/commonTest/kotlin/io/mockative/Coroutines.kt))
+- Effortless multi-threading when using coroutines (see 
+  [Coroutines.kt](shared/src/commonTest/kotlin/io/mockative/Coroutines.kt))
 - Concise, non-intrusive, type-safe API
 - Mocking of **interfaces only**
 - Supports both [expression](#stubbing-using-expressions)
   and [matcher](#stubbing-using-callable-references) based stubbing
   and [verification](#verification)
+- Supports [implicit stubbing](#implicit-stubbing-of-functions-returning-unit) of functions 
+  returning `Unit` 
 
 ## Installation for Multiplatform projects
 
 Mockative uses [KSP] to generate mock classes for interfaces, and as such, it requires adding the
 KSP plugin in addition to adding the runtime library and symbol processor dependencies.
 
-### build.gradle.kts
+**build.gradle.kts**
 
 ```kotlin
 plugins {
@@ -153,6 +155,40 @@ following additional `then` function:
 | Function                                   | Description                                                                                                      |
 | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
 | `then(block: (args: Array<Any?>) -> Any?)` | Invokes the specified block. The argument passed to the block is an array of arguments passed to the invocation. |
+
+### Implicit stubbing of functions returning Unit
+
+An experimental API has been added as opt-in for stubbing functions returning `Unit` by default, 
+based on the idea that such functions are more typically used for verification than stubbing, and 
+are trivially stubbed automatically.
+
+You can opt-in to this behaviour on the project level through your **build.gradle.kts** file:
+
+**build.gradle.kts**
+
+```kotlin
+ksp {
+    arg("mockative.stubsUnitByDefault", "true")
+}
+```
+
+Alternatively, you can opt-in (or opt-out if you've opted in on the project level), using the 
+`configure(mock, block)` function either inline:
+
+```kotlin
+@Mock val api = configure(mock(classOf<GitHubAPI>())) { stubsUnitByDefault = true }
+```
+
+Or as needed:
+
+```kotlin
+@Mock val api = mock(classOf<GitHubAPI>())
+
+@Test
+fun test() {
+    configure(api) { stubsUnitByDefault = true }
+}
+```
 
 ## Generic Types
 

--- a/mockative-processor/src/main/kotlin/io/mockative/MockWriter.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/MockWriter.kt
@@ -2,7 +2,7 @@ package io.mockative
 
 import java.io.Writer
 
-class MockWriter(private val writer: Writer) {
+class MockWriter(private val writer: Writer, private val stubsUnitByDefault: Boolean) {
     fun appendMock(mock: MockDescriptor) {
         appendPackage(mock)
         writer.appendLine()
@@ -55,7 +55,7 @@ class MockWriter(private val writer: Writer) {
 
         writer.append(" : ")
         writer.append(MockativeTypes.Mockable.name)
-        writer.append("(), ")
+        writer.append("(stubsUnitByDefault = $stubsUnitByDefault), ")
         writer.append(mock.qualifiedName)
 
         if (typeParameters.isNotEmpty()) {

--- a/mockative-processor/src/main/kotlin/io/mockative/MockativeSymbolProcessor.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/MockativeSymbolProcessor.kt
@@ -14,6 +14,7 @@ class MockativeSymbolProcessor(
 
     private val isDebugLogEnabled: Boolean = options["mockative.logging"]?.lowercase() == "debug"
     private val isInfoLogEnabled: Boolean = isDebugLogEnabled || options["mockative.logging"]?.lowercase() == "info"
+    private val stubsUnitByDefault: Boolean = options["mockative.stubsUnitByDefault"].toBoolean()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         debug("Starting")
@@ -50,7 +51,7 @@ class MockativeSymbolProcessor(
                 val dependencies = Dependencies(true, *sources)
                 val os = codeGenerator.createNewFile(dependencies, mock.packageName, mock.mockName)
                 val writer = OutputStreamWriter(os)
-                val mockWriter = MockWriter(writer)
+                val mockWriter = MockWriter(writer, stubsUnitByDefault)
                 mockWriter.appendMock(mock)
                 writer.flush()
 

--- a/mockative-test/build.gradle.kts
+++ b/mockative-test/build.gradle.kts
@@ -35,3 +35,8 @@ kotlin {
 dependencies {
     ksp(project(":mockative-processor"))
 }
+
+ksp {
+    arg("mockative.logging", "debug")
+    arg("mockative.stubsUnitByDefault", "true")
+}

--- a/mockative-test/src/test/resources/io/mockative/NoiseStoreMock.kt
+++ b/mockative-test/src/test/resources/io/mockative/NoiseStoreMock.kt
@@ -1,6 +1,6 @@
 package io.mockative
 
-class NoiseStoreMock : io.mockative.Mockable(), io.mockative.NoiseStore {
+class NoiseStoreMock : io.mockative.Mockable(stubsUnitByDefault = true), io.mockative.NoiseStore {
     override var noises: kotlin.collections.Map<kotlin.String, kotlin.Function0<kotlin.Unit>>
         get() = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Getter("noises"))
         set(value) = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Setter("noises", value))

--- a/mockative-test/src/test/resources/io/mockative/PetStoreMock.kt
+++ b/mockative-test/src/test/resources/io/mockative/PetStoreMock.kt
@@ -1,6 +1,6 @@
 package io.mockative
 
-class PetStoreMock<T> : io.mockative.Mockable(), io.mockative.PetStore<T> where T : kotlin.CharSequence {
+class PetStoreMock<T> : io.mockative.Mockable(stubsUnitByDefault = true), io.mockative.PetStore<T> where T : kotlin.CharSequence {
     override var pets: kotlin.collections.Map<kotlin.String, kotlin.Function0<kotlin.Unit>>
         get() = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Getter("pets"))
         set(value) = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Setter("pets", value))

--- a/mockative/src/commonMain/kotlin/io/mockative/Configure.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/Configure.kt
@@ -1,0 +1,11 @@
+package io.mockative
+
+fun <T : Any> configure(subject: T, block: MockConfiguration.() -> Unit): T {
+    return subject.apply { block(MockConfiguration(asMockable())) }
+}
+
+class MockConfiguration(private val mock: Mockable) {
+    var stubsUnitByDefault: Boolean
+        get() = mock.stubsUnitsByDefault
+        set(value) { mock.stubsUnitsByDefault = value }
+}

--- a/mockative/src/commonMain/kotlin/io/mockative/Configure.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/Configure.kt
@@ -1,9 +1,16 @@
 package io.mockative
 
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@RequiresOptIn(message = "This API is experimental. It may be changed in the future without notice.", level = RequiresOptIn.Level.WARNING)
+annotation class ConfigurationApi
+
+@ConfigurationApi
 fun <T : Any> configure(subject: T, block: MockConfiguration.() -> Unit): T {
     return subject.apply { block(MockConfiguration(asMockable())) }
 }
 
+@ConfigurationApi
 class MockConfiguration(private val mock: Mockable) {
     var stubsUnitByDefault: Boolean
         get() = mock.stubsUnitsByDefault

--- a/mockative/src/commonMain/kotlin/io/mockative/Mockable.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/Mockable.kt
@@ -13,7 +13,8 @@ abstract class Mockable(stubsUnitByDefault: Boolean) {
     private val verifiedInvocations = AtomicSet<Invocation>()
 
     private var isRecording: Boolean by atomic(false)
-    private var stubsUnitsByDefault: Boolean by atomic(stubsUnitByDefault)
+
+    internal var stubsUnitsByDefault: Boolean by atomic(stubsUnitByDefault)
 
     internal fun reset() {
         blockingStubs.clear()

--- a/mockative/src/commonMain/kotlin/io/mockative/Mockable.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/Mockable.kt
@@ -3,7 +3,6 @@ package io.mockative
 import io.mockative.concurrency.AtomicList
 import io.mockative.concurrency.AtomicSet
 import io.mockative.concurrency.atomic
-import io.mockative.matchers.AnyArgumentsMatcher
 
 abstract class Mockable {
 
@@ -14,6 +13,7 @@ abstract class Mockable {
     private val verifiedInvocations = AtomicSet<Invocation>()
 
     private var isRecording: Boolean by atomic(false)
+    private var stubsUnitsByDefault: Boolean by atomic(true)
 
     internal fun reset() {
         blockingStubs.clear()
@@ -25,11 +25,14 @@ abstract class Mockable {
         blockingStubs.add(stub)
     }
 
-    private fun getBlockingStub(invocation: Invocation): BlockingStub {
-        return getBlockingStubOrNull(invocation)
-            ?: getSuspendStubOrNull(invocation)
+    private fun getBlockingStub(invocation: Invocation, returnsUnit: Boolean): BlockingStub {
+        return getBlockingStubOrNull(invocation) ?: if (returnsUnit && stubsUnitsByDefault) {
+            BlockingStub(invocation.toOpenExpectation()) { }.also { addBlockingStub(it) }
+        } else {
+            getSuspendStubOrNull(invocation)
                 ?.let { throw InvalidExpectationError(this, invocation, false, expectations) }
-            ?: throw MissingExpectationError(this, invocation, false, expectations)
+                ?: throw MissingExpectationError(this, invocation, false, expectations)
+        }
     }
 
     private fun getBlockingStubOrNull(invocation: Invocation): BlockingStub? {
@@ -43,11 +46,14 @@ abstract class Mockable {
     private val expectations: List<Expectation>
         get() = suspendStubs.map { it.expectation } + blockingStubs.map { it.expectation }
 
-    private fun getSuspendStub(invocation: Invocation): SuspendStub {
-        return getSuspendStubOrNull(invocation)
-            ?: getBlockingStubOrNull(invocation)
+    private fun getSuspendStub(invocation: Invocation, returnsUnit: Boolean): SuspendStub {
+        return getSuspendStubOrNull(invocation) ?: if (returnsUnit && stubsUnitsByDefault) {
+            SuspendStub(invocation.toOpenExpectation()) { }.also { addSuspendStub(it) }
+        } else {
+            getBlockingStubOrNull(invocation)
                 ?.let { throw InvalidExpectationError(this, invocation, true, expectations) }
-            ?: throw MissingExpectationError(this, invocation, true, expectations)
+                ?: throw MissingExpectationError(this, invocation, true, expectations)
+        }
     }
 
     private fun getSuspendStubOrNull(invocation: Invocation): SuspendStub? {
@@ -121,11 +127,11 @@ abstract class Mockable {
     }
 
     @Suppress("UNCHECKED_CAST")
-    internal open fun <R> invoke(invocation: Invocation): R {
+    internal fun <R> invoke(invocation: Invocation, returnsUnit: Boolean): R {
         if (isRecording) {
             throw StubbingInProgressError(invocation)
         } else {
-            val stub = getBlockingStub(invocation)
+            val stub = getBlockingStub(invocation, returnsUnit)
             val result = stub.invoke(invocation)
             return result as R
         }
@@ -156,19 +162,23 @@ abstract class Mockable {
     }
 
     @Suppress("UNCHECKED_CAST")
-    internal suspend fun <R> suspend(invocation: Invocation): R {
+    internal suspend fun <R> suspend(invocation: Invocation, returnsUnit: Boolean): R {
         if (isRecording) {
             throw StubbingInProgressError(invocation)
         } else {
-            val stub = getSuspendStub(invocation)
+            val stub = getSuspendStub(invocation, returnsUnit)
             val result = stub.invoke(invocation)
             return result as R
         }
     }
 
     companion object {
-        fun <R> invoke(mock: Mockable, invocation: Invocation): R = mock.invoke(invocation)
+        inline fun <reified R> invoke(mock: Mockable, invocation: Invocation): R = invoke(mock, invocation, R::class == Unit::class)
 
-        suspend fun <R> suspend(mock: Mockable, invocation: Invocation): R = mock.suspend(invocation)
+        fun <R> invoke(mock: Mockable, invocation: Invocation, returnsUnit: Boolean): R = mock.invoke(invocation, returnsUnit)
+
+        suspend inline fun <reified R> suspend(mock: Mockable, invocation: Invocation): R = suspend(mock, invocation, R::class == Unit::class)
+
+        suspend fun <R> suspend(mock: Mockable, invocation: Invocation, returnsUnit: Boolean): R = mock.suspend(invocation, returnsUnit)
     }
 }

--- a/mockative/src/commonMain/kotlin/io/mockative/Mockable.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/Mockable.kt
@@ -4,7 +4,7 @@ import io.mockative.concurrency.AtomicList
 import io.mockative.concurrency.AtomicSet
 import io.mockative.concurrency.atomic
 
-abstract class Mockable {
+abstract class Mockable(stubsUnitByDefault: Boolean) {
 
     private class StubbingInProgressError(val invocation: Invocation) : Error()
 
@@ -13,7 +13,7 @@ abstract class Mockable {
     private val verifiedInvocations = AtomicSet<Invocation>()
 
     private var isRecording: Boolean by atomic(false)
-    private var stubsUnitsByDefault: Boolean by atomic(true)
+    private var stubsUnitsByDefault: Boolean by atomic(stubsUnitByDefault)
 
     internal fun reset() {
         blockingStubs.clear()

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -101,4 +101,5 @@ dependencies {
 
 ksp {
     arg("mockative.logging", "debug")
+    arg("mockative.stubsUnitByDefault", "true")
 }

--- a/shared/src/commonMain/kotlin/io/mockative/GitHubService.kt
+++ b/shared/src/commonMain/kotlin/io/mockative/GitHubService.kt
@@ -6,6 +6,12 @@ class GitHubService(
     private val api: GitHubAPI,
     private val dispatchers: ApplicationDispatchers
 ) {
+    suspend fun create(repository: Repository) {
+        return withContext(dispatchers.default) {
+            api.create(repository)
+        }
+    }
+
     suspend fun repository(id: String): Repository? {
         return withContext(dispatchers.default) {
             api.repository(id)

--- a/shared/src/commonTest/kotlin/io/mockative/GitHubServiceMockTests.kt
+++ b/shared/src/commonTest/kotlin/io/mockative/GitHubServiceMockTests.kt
@@ -16,6 +16,19 @@ class GitHubServiceMockTests {
     }
 
     @Test
+    fun whenCallingCreate_thenCreateIsCalled() = runBlockingTest {
+        // given
+        val repository = Repository(id = "mockative/mockative", name = "Mockative")
+
+        // when
+        service.create(repository)
+
+        // then
+        verify(github).coroutine { create(repository) }
+            .wasInvoked(exactly = once)
+    }
+
+    @Test
     fun givenSetupOfSuspendingCommand_whenCallingCommand_thenMockIsUsed() = runBlockingTest {
         // given
         val id = "0efb1b3b-f1b2-41f8-a1d8-368027cc86ee"

--- a/shared/src/commonTest/kotlin/io/mockative/GitHubServiceMockTests.kt
+++ b/shared/src/commonTest/kotlin/io/mockative/GitHubServiceMockTests.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertEquals
 
 class GitHubServiceMockTests {
 
-    @Mock val github = mock(GitHubAPI::class)
+    @Mock val github = mock(classOf<GitHubAPI>())
 
     private val service = GitHubService(github, ApplicationDispatchers.Unconfined)
 


### PR DESCRIPTION
Implements implicit stubbing of members returning `Unit` as an experimental opt-in API.

To opt-in to implicit stubbing on a project level, add the following KSP option:

**build.gradle.kts**
```kotlin
ksp {
    arg("mockative.stubsUnitByDefault", "true")
}
```

Alternatively, you can opt-in (or opt-out if you've opted in on the project level), using the 
`configure(mock, block)` function either inline:

```kotlin
@Mock val api = configure(mock(classOf<GitHubAPI>())) { stubsUnitByDefault = true }
```

Or as needed:

```kotlin
@Mock val api = mock(classOf<GitHubAPI>())

@Test
fun test() {
    configure(api) { stubsUnitByDefault = true }
}
```

### Experimental API

The following function was introduced as an experimental API to allow controlling implicit stubbing of members returning `Unit` on a per-mock level:

```kotlin
fun <T : Any> configure(subject: T, block: MockConfiguration.() -> Unit): T
```