### PR TITLE
Upgrade to Kotlin 1.6.0 & support more Kotlin/Native targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,33 +1,45 @@
-name: All tests
+name: Build
 
 on:
+  pull_request:
   push:
     branches:
       - main
 
+env:
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.compiler.execution.strategy=in-process
+
 jobs:
-  tests:
-    runs-on: ubuntu-latest
+  test-on-macos:
+    runs-on: macos-11
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
     steps:
-    - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.konan
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
-    - name: Set up JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: 16
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 16
 
-    - name: Run Code Generator
-      run: ./gradlew :mockative-code-generator:run
+      - name: Initialize Gradle
+        run: ./gradlew
 
-    - name: Run tests with Gradle
-      run: ./gradlew allTests
+      - name: Run code generator
+        run: ./gradlew :mockative-code-generator:run
+
+      - name: Run tests with Gradle
+        run: ./gradlew allTests
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [ created ]
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.compiler.execution.strategy=in-process
+  SONATYPE_BASE_URL: https://s01.oss.sonatype.org/service/local/
+
+jobs:
+  create-staging-repository:
+    runs-on: ubuntu-latest
+    name: Create staging repository
+    outputs:
+      repository-id: ${{ steps.create.outputs.repository_id }}
+    steps:
+      - id: create
+        name: Create staging repository
+        uses: nexus-actions/create-nexus-staging-repo@v1.1
+        with:
+          username: ${{ secrets.SONATYPE_USERNAME }}
+          password: ${{ secrets.SONATYPE_PASSWORD }}
+          staging_profile_id: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
+          base_url: ${{ env.SONATYPE_BASE_URL }}
+          description: Created by Release (Create staging repository) for mockative/mockative
+
+  publish-on-macos:
+    runs-on: macos-11
+    needs:
+      - create-staging-repository
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.konan
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 16
+
+      - name: Initialize Gradle
+        run: ./gradlew
+
+      - name: Run code generator
+        run: ./gradlew :mockative-code-generator:run
+
+      - name: Publish
+        shell: bash
+        run: |
+          ./gradlew publishAllPublicationsToSonatypeRepository \
+            -Psigning.key='${{ secrets.SIGNING_KEY }}' \
+            -Psigning.keyId='${{ secrets.SIGNING_KEY_ID }}' \
+            -Psigning.password='${{ secrets.SIGNING_PASSWORD }}' \
+            -Psonatype.username='${{ secrets.SONATYPE_USERNAME }}' \
+            -Psonatype.password='${{ secrets.SONATYPE_PASSWORD }}' \
+            -Psonatype.repository='${{ needs.create-staging-repository.outputs.repository-id }}'
+
+  macos-host-check:
+    name: Check on macOS
+    runs-on: macos-11
+    needs:
+      - create-staging-repository
+      - publish-on-macos
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.konan
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 16
+
+      - name: Check
+        run: |
+          ./gradlew :tools:check-publication:build \
+            -Pcheck_publication \
+            -Psonatype.username='${{ secrets.SONATYPE_USERNAME }}' \
+            -Psonatype.password='${{ secrets.SONATYPE_PASSWORD }}' \
+            -Psonatype.repository='${{ needs.create-staging-repository.outputs.repository-id }}'
+
+  close-staging-repository:
+    runs-on: ubuntu-latest
+    needs:
+      - create-staging-repository
+      - macos-host-check
+    if: ${{ always() && needs.create-staging-repository.result == 'success' }}
+    steps:
+      - name: Discard
+        if: ${{ needs.macos-host-check.result != 'success' }}
+        uses: nexus-actions/drop-nexus-staging-repo@v1
+        with:
+          username: ${{ secrets.SONATYPE_USERNAME }}
+          password: ${{ secrets.SONATYPE_PASSWORD }}
+          base_url: ${{ env.SONATYPE_BASE_URL }}
+          staging_repository_id: ${{ needs.create-staging-repository.outputs.repository-id }}
+
+      - name: Close
+        if: ${{ needs.macos-host-check.result == 'success' }}
+        uses: nexus-actions/release-nexus-staging-repo@v1.2
+        with:
+          username: ${{ secrets.SONATYPE_USERNAME }}
+          password: ${{ secrets.SONATYPE_PASSWORD }}
+          staging_repository_id: ${{ needs.create-staging-repository.outputs.repository-id }}
+          base_url: ${{ env.SONATYPE_BASE_URL }}
+          close_only: true

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 local.properties
 .project
 .settings/
+tools/*/build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ buildscript {
     }
 
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
-        classpath("com.android.tools.build:gradle:7.0.3")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0")
+        classpath("com.android.tools.build:gradle:7.0.4")
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,4 +4,10 @@ plugins {
 
 repositories {
     gradlePluginPortal()
+    google()
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0")
+    implementation("com.android.tools.build:gradle:7.0.3")
 }

--- a/buildSrc/src/main/kotlin/convention.multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/convention.multiplatform.gradle.kts
@@ -1,0 +1,103 @@
+plugins {
+    kotlin("multiplatform")
+}
+
+kotlin {
+    jvm()
+
+    js {
+        browser()
+        nodejs()
+    }
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    watchosArm32()
+    watchosArm64()
+    watchosX86()
+    watchosX64()
+    watchosSimulatorArm64()
+
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+
+    macosX64()
+    macosArm64()
+
+    linuxArm64()
+    linuxArm32Hfp()
+    linuxX64()
+
+    mingwX64()
+    mingwX86()
+
+    wasm32()
+
+    @Suppress("UNUSED_VARIABLE")
+    sourceSets {
+        // Common
+        val commonMain by getting
+
+        // JVM
+        val jvmMain by getting
+
+        // JS
+        val jsMain by getting
+
+        // Native
+        val nativeMain by creating { dependsOn(commonMain) }
+
+        // Darwin (iOS, watchOS, tvOS, macOS)
+        val darwinMain by creating { dependsOn(nativeMain) }
+
+        // iOS
+        val iosMain by creating { dependsOn(darwinMain) }
+
+        val iosX64Main by getting { dependsOn(iosMain) }
+        val iosArm64Main by getting { dependsOn(iosMain) }
+        val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
+
+        // watchOS
+        val watchosMain by creating { dependsOn(darwinMain) }
+
+        val watchosArm32Main by getting { dependsOn(watchosMain) }
+        val watchosArm64Main by getting { dependsOn(watchosMain) }
+        val watchosX86Main by getting { dependsOn(watchosMain) }
+        val watchosX64Main by getting { dependsOn(watchosMain) }
+        val watchosSimulatorArm64Main by getting { dependsOn(watchosMain) }
+
+        // tvOS
+        val tvosMain by creating { dependsOn(darwinMain) }
+
+        val tvosArm64Main by getting { dependsOn(tvosMain) }
+        val tvosX64Main by getting { dependsOn(tvosMain) }
+        val tvosSimulatorArm64Main by getting { dependsOn(tvosMain) }
+
+        // macOS
+        val macosMain by creating { dependsOn(darwinMain) }
+
+        val macosX64Main by getting { dependsOn(macosMain) }
+        val macosArm64Main by getting { dependsOn(macosMain) }
+
+        // Linux
+        val linuxMain by creating { dependsOn(nativeMain) }
+
+        val linuxArm64Main by getting { dependsOn(linuxMain) }
+        val linuxArm32HfpMain by getting { dependsOn(linuxMain) }
+        val linuxX64Main by getting { dependsOn(linuxMain) }
+
+        // mingw (Windows)
+        val mingwMain by creating { dependsOn(nativeMain) }
+
+        val mingwX64Main by getting { dependsOn(mingwMain) }
+        val mingwX86Main by getting { dependsOn(mingwMain) }
+
+        // wasm
+        val wasmMain by creating { dependsOn(commonMain) }
+
+        val wasm32Main by getting { dependsOn(wasmMain) }
+    }
+}

--- a/buildSrc/src/main/kotlin/convention.publication.gradle.kts
+++ b/buildSrc/src/main/kotlin/convention.publication.gradle.kts
@@ -6,19 +6,24 @@ plugins {
 }
 
 val props = Properties().apply {
+    // Load `gradle.properties`, environment variables and command-line arguments
+    project.properties.forEach { (key, value) ->
+        if (value != null) {
+            this[key] = value
+        }
+    }
+
     // Load `local.properties`
     loadFile(project.rootProject.file("local.properties"), required = false)
 
     // Load environment variables
-    loadEnv("gpr.user", "GPR_USER")
-    loadEnv("gpr.key", "GPR_KEY")
-
     loadEnv("signing.keyId", "SIGNING_KEY_ID")
     loadEnv("signing.key", "SIGNING_KEY")
     loadEnv("signing.password", "SIGNING_PASSWORD")
 
-    loadEnv("ossrh.username", "OSSRH_USERNAME")
-    loadEnv("ossrh.password", "OSSRH_PASSWORD")
+    loadEnv("sonatype.username", "SONATYPE_USERNAME")
+    loadEnv("sonatype.password", "SONATYPE_PASSWORD")
+    loadEnv("sonatype.repository", "SONATYPE_REPOSITORY")
 }
 
 val javadocJar by tasks.registering(Jar::class) {
@@ -28,20 +33,14 @@ val javadocJar by tasks.registering(Jar::class) {
 publishing {
     repositories {
         maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/mockative/mockative")
-            credentials {
-                username = props.getProperty("gpr.user")
-                password = props.getProperty("gpr.key")
-            }
-        }
-
-        maven {
             name = "Sonatype"
-            url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2")
+            url = props.getProperty("sonatype.repository")
+                ?.let { uri("https://s01.oss.sonatype.org/service/local/staging/deployByRepositoryId/$it") }
+                ?: uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2")
+
             credentials {
-                username = props.getProperty("ossrh.username")
-                password = props.getProperty("ossrh.password")
+                username = props.getProperty("sonatype.username")
+                password = props.getProperty("sonatype.password")
             }
         }
 
@@ -49,8 +48,8 @@ publishing {
             name = "SonatypeSnapshot"
             url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
             credentials {
-                username = props.getProperty("ossrh.username")
-                password = props.getProperty("ossrh.password")
+                username = props.getProperty("sonatype.username")
+                password = props.getProperty("sonatype.password")
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,5 +11,5 @@ android.useAndroidX=true
 
 #Versioning
 project.group=io.mockative
-project.version=1.0.7
+project.version=1.1.0
 

--- a/mockative-processor/build.gradle.kts
+++ b/mockative-processor/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation(project(":mockative"))
-                implementation("com.google.devtools.ksp:symbol-processing-api:1.5.31-1.0.0")
+                implementation("com.google.devtools.ksp:symbol-processing-api:1.6.0-1.0.1")
             }
 
             kotlin.srcDir("src/main/kotlin")

--- a/mockative/build.gradle.kts
+++ b/mockative/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("multiplatform")
+    id("convention.multiplatform")
     id("convention.publication")
 }
 
@@ -7,34 +7,12 @@ group = findProperty("project.group") as String
 version = findProperty("project.version") as String
 
 kotlin {
-    jvm()
-
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
-
-    js {
-        browser()
-        nodejs()
-    }
-
+    @Suppress("UNUSED")
     sourceSets {
+        // Common
         val commonMain by getting {
-            dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2-native-mt")
-            }
-
             kotlin.srcDirs("$buildDir/generated/mockative-code-generator")
         }
-
-        val nativeMain by creating { dependsOn(commonMain) }
-
-        val darwinMain by creating { dependsOn(nativeMain) }
-
-        val iosMain by creating { dependsOn(darwinMain) }
-        val iosX64Main by getting { dependsOn(iosMain) }
-        val iosArm64Main by getting { dependsOn(iosMain) }
-        val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
 
         all {
             languageSettings {

--- a/mockative/src/main/AndroidManifest.xml
+++ b/mockative/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="io.mockative">
+</manifest>

--- a/mockative/src/wasmMain/kotlin/io/mockative/concurrency/AtomicReference.kt
+++ b/mockative/src/wasmMain/kotlin/io/mockative/concurrency/AtomicReference.kt
@@ -1,0 +1,8 @@
+package io.mockative.concurrency
+
+internal actual class AtomicReference<T> actual constructor(actual var value: T) {
+    actual fun compareAndSet(expected: T, new: T): Boolean {
+        value = new
+        return true
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,8 +6,8 @@ pluginManagement {
     }
 
     plugins {
-        kotlin("multiplatform") version "1.5.31" apply false
-        id("com.google.devtools.ksp") version "1.5.31-1.0.1" apply false
+        kotlin("multiplatform") version "1.6.0" apply false
+        id("com.google.devtools.ksp") version "1.6.0-1.0.1" apply false
     }
 }
 
@@ -18,3 +18,7 @@ include(":mockative")
 include(":mockative-processor")
 include(":mockative-test")
 include(":mockative-code-generator")
+
+if (startParameter.projectProperties.containsKey("check_publication")) {
+    include(":tools:check-publication")
+}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -96,8 +96,7 @@ android {
 }
 
 dependencies {
-//    ksp(project(":mockative-processor"))
-    ksp("io.mockative:mockative-processor:1.0.7")
+    ksp(project(":mockative-processor"))
 }
 
 ksp {

--- a/tools/check-publication/build.gradle.kts
+++ b/tools/check-publication/build.gradle.kts
@@ -1,0 +1,49 @@
+plugins {
+    id("convention.multiplatform")
+    id("com.android.library")
+
+    id("com.google.devtools.ksp")
+}
+
+version = findProperty("project.version") as String
+
+kotlin {
+    android()
+}
+
+android {
+    compileSdk = 31
+}
+
+inline fun <reified T> getProperty(key: String): T {
+    return findProperty(key) as T? ?: throw NoSuchElementException("A project property with key '$key' was not found.")
+}
+
+val sonatypeRepository: String = getProperty("sonatype.repository")
+val sonatypeUsername: String = getProperty("sonatype.username")
+val sonatypePassword: String = getProperty("sonatype.password")
+
+repositories {
+    maven {
+        url = uri("https://s01.oss.sonatype.org/service/local/staging/deployByRepositoryId/$sonatypeRepository")
+
+        credentials {
+            setUsername(sonatypeUsername)
+            setPassword(sonatypePassword)
+        }
+    }
+}
+
+kotlin {
+    sourceSets {
+        val commonTest by getting {
+            dependencies {
+                implementation("io.mockative:mockative:$version")
+            }
+        }
+    }
+}
+
+dependencies {
+    ksp("io.mockative:mockative-processor:$version")
+}

--- a/tools/check-publication/src/kotlin/commonTest/Dummy.kt
+++ b/tools/check-publication/src/kotlin/commonTest/Dummy.kt
@@ -1,0 +1,1 @@
+object Dummy

--- a/tools/check-publication/src/main/AndroidManifest.xml
+++ b/tools/check-publication/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="io.mockative" />


### PR DESCRIPTION
Upgrades Mockative to build using Kotlin 1.6.0, which brings along the benefit of building Windows (MinGW) targets on macOS agents. This Pull Request also expands the list of supported targets to encompass all but the two LinuxMIPS targets, which still cannot be built on a macOS host.