### PR TITLE
Fixes incorrect range verification when only using atLeast

### DIFF
--- a/mockative/src/commonMain/kotlin/io/mockative/RangeVerifier.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/RangeVerifier.kt
@@ -9,7 +9,7 @@ internal class RangeVerifier(
         val matchingInvocations = invocations.filter { expectation.matches(it) }
 
         val actual = matchingInvocations.size
-        if (actual !in (atLeast ?: 0) until (atMost ?: 0) + 1) {
+        if (actual < atLeast ?: 0 || atMost != null && actual > atMost) {
             throw RangeVerificationError(instance, atLeast, atMost, actual, expectation, invocations)
         }
 

--- a/shared/src/commonTest/kotlin/io/mockative/GitHubServiceMockTests.kt
+++ b/shared/src/commonTest/kotlin/io/mockative/GitHubServiceMockTests.kt
@@ -25,7 +25,7 @@ class GitHubServiceMockTests {
 
         // then
         verify(github).coroutine { create(repository) }
-            .wasInvoked(exactly = once)
+            .wasInvoked(atLeast = once)
     }
 
     @Test


### PR DESCRIPTION
Fixes an issue with the `RangeVerifier` implementation, where it would fail verification anytime an `atMost` parameter was not provided.