### PR TITLE
Fixed mock members with generic type parmeters as return type

### DIFF
--- a/mockative-processor/src/main/kotlin/io/mockative/FunctionWriter.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/FunctionWriter.kt
@@ -105,6 +105,8 @@ class FunctionWriter(private val writer: Writer) {
         }
 
         writer.append(')')
+        writer.append(", ")
+        writer.append(if (function.returnType == "kotlin.Unit") "true" else "false")
         writer.append(')')
     }
 }

--- a/mockative-processor/src/main/kotlin/io/mockative/PropertyWriter.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/PropertyWriter.kt
@@ -43,11 +43,18 @@ class PropertyWriter(private val writer: Writer) {
     }
 
     private fun appendGetter(property: MockDescriptor.Property) {
-        writer.append("get() = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Getter(\"${property.name}\"))")
+        writer.append("get() = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Getter(")
+        writer.append('"')
+        writer.append(property.name)
+        writer.append('"')
+        writer.append(')')
+        writer.append(", ")
+        writer.append(if (property.type == "kotlin.Unit") "true" else "false")
+        writer.append(')')
     }
 
     private fun appendSetter(property: MockDescriptor.Property) {
-        writer.append("set(value) = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Setter(\"${property.name}\", value))")
+        writer.append("set(value) = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Setter(\"${property.name}\", value), true)")
     }
 
     private fun appendName(property: MockDescriptor.Property) {

--- a/mockative-test/src/main/kotlin/io/mockative/PetStore.kt
+++ b/mockative-test/src/main/kotlin/io/mockative/PetStore.kt
@@ -11,4 +11,6 @@ interface PetStore<T : CharSequence> {
     fun <P : Number> generic(type: T, pet: P): CharSequence
 
     fun clear()
+
+    fun <R> call(function: Any.() -> R): R
 }

--- a/mockative-test/src/test/resources/io/mockative/NoiseStoreMock.kt
+++ b/mockative-test/src/test/resources/io/mockative/NoiseStoreMock.kt
@@ -2,12 +2,12 @@ package io.mockative
 
 class NoiseStoreMock : io.mockative.Mockable(stubsUnitByDefault = true), io.mockative.NoiseStore {
     override var noises: kotlin.collections.Map<kotlin.String, kotlin.Function0<kotlin.Unit>>
-        get() = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Getter("noises"))
-        set(value) = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Setter("noises", value))
+        get() = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Getter("noises"), false)
+        set(value) = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Setter("noises", value), true)
     override val readOnlyNoises: kotlin.collections.Map<kotlin.String, kotlin.Function0<kotlin.Unit>>
-        get() = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Getter("readOnlyNoises"))
+        get() = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Getter("readOnlyNoises"), false)
 
-    override fun addNoise(name: kotlin.String, play: kotlin.Function0<kotlin.Unit>): kotlin.Unit = io.mockative.Mockable.invoke<kotlin.Unit>(this, io.mockative.Invocation.Function("addNoise", listOf<Any?>(name, play)))
-    override fun clear(): kotlin.Unit = io.mockative.Mockable.invoke<kotlin.Unit>(this, io.mockative.Invocation.Function("clear", emptyList<Any?>()))
-    override fun noise(name: kotlin.String): kotlin.Function0<kotlin.Unit> = io.mockative.Mockable.invoke<kotlin.Function0<kotlin.Unit>>(this, io.mockative.Invocation.Function("noise", listOf<Any?>(name)))
+    override fun addNoise(name: kotlin.String, play: kotlin.Function0<kotlin.Unit>): kotlin.Unit = io.mockative.Mockable.invoke<kotlin.Unit>(this, io.mockative.Invocation.Function("addNoise", listOf<Any?>(name, play)), true)
+    override fun clear(): kotlin.Unit = io.mockative.Mockable.invoke<kotlin.Unit>(this, io.mockative.Invocation.Function("clear", emptyList<Any?>()), true)
+    override fun noise(name: kotlin.String): kotlin.Function0<kotlin.Unit> = io.mockative.Mockable.invoke<kotlin.Function0<kotlin.Unit>>(this, io.mockative.Invocation.Function("noise", listOf<Any?>(name)), false)
 }

--- a/mockative-test/src/test/resources/io/mockative/PetStoreMock.kt
+++ b/mockative-test/src/test/resources/io/mockative/PetStoreMock.kt
@@ -2,14 +2,15 @@ package io.mockative
 
 class PetStoreMock<T> : io.mockative.Mockable(stubsUnitByDefault = true), io.mockative.PetStore<T> where T : kotlin.CharSequence {
     override var pets: kotlin.collections.Map<kotlin.String, kotlin.Function0<kotlin.Unit>>
-        get() = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Getter("pets"))
-        set(value) = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Setter("pets", value))
+        get() = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Getter("pets"), false)
+        set(value) = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Setter("pets", value), true)
     override val readOnlyPets: kotlin.collections.Map<kotlin.String, kotlin.Function0<kotlin.Unit>>
-        get() = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Getter("readOnlyPets"))
+        get() = io.mockative.Mockable.invoke(this, io.mockative.Invocation.Getter("readOnlyPets"), false)
 
-    override fun add(pet: io.mockative.Pet): kotlin.Unit = io.mockative.Mockable.invoke<kotlin.Unit>(this, io.mockative.Invocation.Function("add", listOf<Any?>(pet)))
-    override fun clear(): kotlin.Unit = io.mockative.Mockable.invoke<kotlin.Unit>(this, io.mockative.Invocation.Function("clear", emptyList<Any?>()))
-    override fun <P> generic(type: T, pet: P): kotlin.CharSequence where P : kotlin.Number = io.mockative.Mockable.invoke<kotlin.CharSequence>(this, io.mockative.Invocation.Function("generic", listOf<Any?>(type, pet)))
-    override fun pet(name: kotlin.String): io.mockative.Pet = io.mockative.Mockable.invoke<io.mockative.Pet>(this, io.mockative.Invocation.Function("pet", listOf<Any?>(name)))
-    override fun petOrNull(name: kotlin.String): io.mockative.Pet? = io.mockative.Mockable.invoke<io.mockative.Pet?>(this, io.mockative.Invocation.Function("petOrNull", listOf<Any?>(name)))
+    override fun add(pet: io.mockative.Pet): kotlin.Unit = io.mockative.Mockable.invoke<kotlin.Unit>(this, io.mockative.Invocation.Function("add", listOf<Any?>(pet)), true)
+    override fun <R> call(function: kotlin.Function1<kotlin.Any, R>): R where R : kotlin.Any? = io.mockative.Mockable.invoke<R>(this, io.mockative.Invocation.Function("call", listOf<Any?>(function)), false)
+    override fun clear(): kotlin.Unit = io.mockative.Mockable.invoke<kotlin.Unit>(this, io.mockative.Invocation.Function("clear", emptyList<Any?>()), true)
+    override fun <P> generic(type: T, pet: P): kotlin.CharSequence where P : kotlin.Number = io.mockative.Mockable.invoke<kotlin.CharSequence>(this, io.mockative.Invocation.Function("generic", listOf<Any?>(type, pet)), false)
+    override fun pet(name: kotlin.String): io.mockative.Pet = io.mockative.Mockable.invoke<io.mockative.Pet>(this, io.mockative.Invocation.Function("pet", listOf<Any?>(name)), false)
+    override fun petOrNull(name: kotlin.String): io.mockative.Pet? = io.mockative.Mockable.invoke<io.mockative.Pet?>(this, io.mockative.Invocation.Function("petOrNull", listOf<Any?>(name)), false)
 }

--- a/mockative/src/commonMain/kotlin/io/mockative/Mockable.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/Mockable.kt
@@ -174,11 +174,7 @@ abstract class Mockable(stubsUnitByDefault: Boolean) {
     }
 
     companion object {
-        inline fun <reified R> invoke(mock: Mockable, invocation: Invocation): R = invoke(mock, invocation, R::class == Unit::class)
-
         fun <R> invoke(mock: Mockable, invocation: Invocation, returnsUnit: Boolean): R = mock.invoke(invocation, returnsUnit)
-
-        suspend inline fun <reified R> suspend(mock: Mockable, invocation: Invocation): R = suspend(mock, invocation, R::class == Unit::class)
 
         suspend fun <R> suspend(mock: Mockable, invocation: Invocation, returnsUnit: Boolean): R = mock.suspend(invocation, returnsUnit)
     }


### PR DESCRIPTION
As reported by #20, when an interface declares a member where the return type is one of its generic type parameters, the use of the `Mockable.invoke` function fails to compile correctly.

This MR aims to rectify that by generating the value of the `returnsUnit` argument at compile time rather than at runtime.