### PR TITLE
Adds builders for stubbing and verification with less type info

### DIFF
--- a/mockative-code-generator/src/main/resources/io/mockative/generator/GivenBuilder
+++ b/mockative-code-generator/src/main/resources/io/mockative/generator/GivenBuilder
@@ -25,9 +25,15 @@ class GivenBuilder<T : Any>(private val receiver: T) {
     fun <V> setter(property: KMutableProperty<V>): GivenSetterBuilder<V> = GivenSetterBuilder(receiver.asMockable(), property.name)
     fun <V> setter(property: String): GivenSetterBuilder<V> = GivenSetterBuilder(receiver.asMockable(), property)
 
+    fun <R> function(name: String): GivenFunctionBuilder<R> = GivenFunctionBuilder(receiver.asMockable(), name)
+    fun <R> function(function: KFunction<R>): GivenFunctionBuilder<R> = GivenFunctionBuilder(receiver.asMockable(), function.name)
+
     fun <R, F> function(function: F): GivenFunction0Builder<R> where F : () -> R, F : KFunction<R> = GivenFunction0Builder(receiver.asMockable(), function)
     fun <R, F> function(function: F, @Suppress("unused") type: KFunction0): GivenFunction0Builder<R> where F : () -> R, F : KFunction<R> = GivenFunction0Builder(receiver.asMockable(), function)
 #functions#
+
+    fun <R> suspendFunction(name: String): GivenSuspendFunctionBuilder<R> = GivenSuspendFunctionBuilder(receiver.asMockable(), name)
+    fun <R> suspendFunction(function: KFunction<R>): GivenSuspendFunctionBuilder<R> = GivenSuspendFunctionBuilder(receiver.asMockable(), function.name)
 
     fun <R, F> suspendFunction(function: F): GivenSuspendFunction0Builder<R> where F : suspend () -> R, F : KFunction<R> = GivenSuspendFunction0Builder(receiver.asMockable(), function)
     fun <R, F> suspendFunction(function: F, @Suppress("unused") type: KFunction0): GivenSuspendFunction0Builder<R> where F : suspend () -> R, F : KFunction<R> = GivenSuspendFunction0Builder(receiver.asMockable(), function)

--- a/mockative-code-generator/src/main/resources/io/mockative/generator/VerifyThatBuilder
+++ b/mockative-code-generator/src/main/resources/io/mockative/generator/VerifyThatBuilder
@@ -28,12 +28,14 @@ class VerifyThatBuilder<T : Any>(private val receiver: T) {
 
 
     fun function(function: String): VerifyFunctionBuilder = VerifyFunctionBuilder(receiver.asMockable(), function)
+    fun <R> function(function: KFunction<R>): VerifyFunctionBuilder = VerifyFunctionBuilder(receiver.asMockable(), function.name)
 
     fun <R, F> function(function: F): Verification where F : () -> R, F : KFunction<R> = Verification(receiver.asMockable(), Expectation.Function(function.name, SpecificArgumentsMatcher(emptyList())))
     fun <R, F> function(function: F, type: KFunction0): Verification where F : () -> R, F : KFunction<R> = Verification(receiver.asMockable(), Expectation.Function(function.name, SpecificArgumentsMatcher(emptyList())))
 
 #functions#
     fun suspendFunction(function: String): VerifyFunctionBuilder = VerifyFunctionBuilder(receiver.asMockable(), function)
+    fun <R> suspendFunction(function: KFunction<R>): VerifyFunctionBuilder = VerifyFunctionBuilder(receiver.asMockable(), function.name)
 
     fun <R, F> suspendFunction(function: F): Verification where F : suspend () -> R, F : KFunction<R> = Verification(receiver.asMockable(), Expectation.Function(function.name, SpecificArgumentsMatcher(emptyList())))
     fun <R, F> suspendFunction(function: F, type: KFunction0): Verification where F : suspend () -> R, F : KFunction<R> = Verification(receiver.asMockable(), Expectation.Function(function.name, SpecificArgumentsMatcher(emptyList())))

--- a/mockative/src/commonMain/kotlin/io/mockative/GivenFunctionBuilder.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/GivenFunctionBuilder.kt
@@ -1,0 +1,22 @@
+package io.mockative
+
+import io.mockative.matchers.ArgumentsMatcher
+import io.mockative.matchers.Matcher
+import io.mockative.matchers.SpecificArgumentsMatcher
+
+class GivenFunctionBuilder<R>(private val mock: Mockable, private val name: String) {
+    fun whenInvokedWith(vararg matchers: Matcher<*>): ResultBuilder {
+        val arguments = SpecificArgumentsMatcher(matchers.toList())
+        return ResultBuilder(arguments)
+    }
+
+    inner class ResultBuilder(private val arguments: ArgumentsMatcher) : AnyResultBuilder<R> {
+        fun then(block: (args: Array<Any?>) -> R) {
+            val expectation = Expectation.Function(name, arguments)
+            val stub = BlockingStub(expectation, block)
+            mock.addBlockingStub(stub)
+        }
+
+        override fun thenInvoke(block: () -> R) = then { block() }
+    }
+}

--- a/mockative/src/commonMain/kotlin/io/mockative/GivenSuspendFunctionBuilder.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/GivenSuspendFunctionBuilder.kt
@@ -1,0 +1,23 @@
+package io.mockative
+
+import io.mockative.matchers.ArgumentsMatcher
+import io.mockative.matchers.Matcher
+import io.mockative.matchers.SpecificArgumentsMatcher
+
+class GivenSuspendFunctionBuilder<R>(private val mock: Mockable, private val name: String) {
+    fun whenInvokedWith(vararg matchers: Matcher<*>): ResultBuilder {
+        val arguments = SpecificArgumentsMatcher(matchers.toList())
+        return ResultBuilder(arguments)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    inner class ResultBuilder(private val arguments: ArgumentsMatcher) : AnySuspendResultBuilder<R> {
+        fun then(block: suspend (args: Array<Any?>) -> R) {
+            val expectation = Expectation.Function(name, arguments)
+            val stub = SuspendStub(expectation, block)
+            mock.addSuspendStub(stub)
+        }
+
+        override fun thenInvoke(block: suspend () -> R) = then { block() }
+    }
+}

--- a/mockative/src/commonMain/kotlin/io/mockative/Matchers.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/Matchers.kt
@@ -3,6 +3,10 @@ package io.mockative
 import io.mockative.matchers.*
 import kotlin.reflect.KClass
 
+inline fun wildcard(): WildcardMatcher<*> {
+    return WildcardMatcher<Any?>()
+}
+
 inline fun <reified T> anything(): AnythingMatcher<T> {
     return AnythingMatcher()
 }

--- a/mockative/src/commonMain/kotlin/io/mockative/matchers/WildcardMatcher.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/matchers/WildcardMatcher.kt
@@ -1,0 +1,11 @@
+package io.mockative.matchers
+
+class WildcardMatcher<T> : Matcher<T> {
+    override fun matches(value: Any?): Boolean {
+        return true
+    }
+
+    override fun toString(): String {
+        return "*"
+    }
+}

--- a/shared/src/commonMain/kotlin/io/mockative/FileService.kt
+++ b/shared/src/commonMain/kotlin/io/mockative/FileService.kt
@@ -1,0 +1,11 @@
+package io.mockative
+
+class FileService(private val client: S3Client) {
+    fun getFileSync(id: String): File {
+        return client.getObjectSync(GetObjectRequest(id)) { File(it.body) }
+    }
+
+    suspend fun getFile(id: String): File {
+        return client.getObject(GetObjectRequest(id)) { File(it.body) }
+    }
+}

--- a/shared/src/commonMain/kotlin/io/mockative/S3Client.kt
+++ b/shared/src/commonMain/kotlin/io/mockative/S3Client.kt
@@ -1,0 +1,12 @@
+package io.mockative
+
+data class GetObjectRequest(val id: String)
+data class GetObjectResponse(val body: String)
+
+data class File(val body: String)
+
+interface S3Client {
+    fun <T> getObjectSync(input: GetObjectRequest, block: (GetObjectResponse) -> T): T
+
+    suspend fun <T> getObject(input: GetObjectRequest, block: suspend (GetObjectResponse) -> T): T
+}

--- a/shared/src/commonTest/kotlin/io/mockative/FileServiceTests.kt
+++ b/shared/src/commonTest/kotlin/io/mockative/FileServiceTests.kt
@@ -1,0 +1,87 @@
+package io.mockative
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FileServiceTests {
+    @Mock
+    private val s3Client = mock(classOf<S3Client>())
+
+    private val fileService = FileService(s3Client)
+
+    @Test
+    fun givenGetObjectSync_whenGettingFileSync_thenFileIsReturned() {
+        // Given
+        val id = "9142a04a-5377-4792-89c1-2bd4f6d742fe"
+        val expected = File("the-body")
+
+        val request = GetObjectRequest(id)
+
+        given(s3Client).function<File>(s3Client::getObjectSync)
+            .whenInvokedWith(eq(request), wildcard())
+            .thenReturn(expected)
+
+        // When
+        val file = fileService.getFileSync(id)
+
+        // Then
+        assertEquals(expected, file)
+    }
+
+    @Test
+    fun givenGetObjectSyncString_whenGettingFileSync_thenFileIsReturned() {
+        // Given
+        val id = "9142a04a-5377-4792-89c1-2bd4f6d742fe"
+        val expected = File("the-body")
+
+        val request = GetObjectRequest(id)
+
+        given(s3Client).function<File>("getObjectSync")
+            .whenInvokedWith(eq(request), wildcard())
+            .thenReturn(expected)
+
+        // When
+        val file = fileService.getFileSync(id)
+
+        // Then
+        assertEquals(expected, file)
+    }
+
+    @Test
+    fun givenGetObject_whenGettingFile_thenFileIsReturned() = runBlockingTest {
+        // Given
+        val id = "9142a04a-5377-4792-89c1-2bd4f6d742fe"
+        val expected = File("the-body")
+
+        val request = GetObjectRequest(id)
+
+        given(s3Client).suspendFunction<File>(s3Client::getObject)
+            .whenInvokedWith(eq(request), wildcard())
+            .thenReturn(expected)
+
+        // When
+        val file = fileService.getFile(id)
+
+        // Then
+        assertEquals(expected, file)
+    }
+
+    @Test
+    fun givenGetObjectString_whenGettingFile_thenFileIsReturned() = runBlockingTest {
+        // Given
+        val id = "9142a04a-5377-4792-89c1-2bd4f6d742fe"
+        val expected = File("the-body")
+
+        val request = GetObjectRequest(id)
+
+        given(s3Client).suspendFunction<File>("getObject")
+            .whenInvokedWith(eq(request), wildcard())
+            .thenReturn(expected)
+
+        // When
+        val file = fileService.getFile(id)
+
+        // Then
+        assertEquals(expected, file)
+    }
+}


### PR DESCRIPTION
### What's Changed
There are cases where type information cannot be inferred and providing the type information using the `fun2<P1, P2>()` etc. functions either doesn't work or is cumbersome. To accommodate these use cases, I'm introducing stubbing and verification using either a string or a play `KFunction<R>`, where only specifying the return type is a requirement to begin stubbing.

This aims to solve the issue reported in #37.