### PR TITLE
Add default/fallback implementations of functions from Any

### DIFF
--- a/mockative-processor/src/main/kotlin/io/mockative/ksp/KSFunctionDeclaration.Mockative.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/ksp/KSFunctionDeclaration.Mockative.kt
@@ -1,0 +1,28 @@
+package io.mockative.ksp
+
+import com.google.devtools.ksp.symbol.KSClassifierReference
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+
+fun KSFunctionDeclaration.isFromAny() =
+    when (simpleName.asString()) {
+        "hashCode", "toString" -> typeParameters.isEmpty() && parameters.isEmpty()
+        else -> when {
+            isAnyEquals() -> true
+            else -> false
+        }
+    }
+
+private fun KSFunctionDeclaration.isAnyEquals(): Boolean {
+    if (simpleName.asString() != "equals") return false
+    if (typeParameters.isNotEmpty()) return false
+    if (parameters.size != 1) return false
+
+    val parameter = parameters[0]
+    if (parameter.name?.asString() != "other") return false
+
+    val parameterType = parameter.type.element
+    if (parameterType !is KSClassifierReference) return false
+    if (parameterType.referencedName() != "Any") return false
+
+    return true
+}

--- a/shared/src/commonMain/kotlin/io/mockative/DefaultInvocationTestSubject.kt
+++ b/shared/src/commonMain/kotlin/io/mockative/DefaultInvocationTestSubject.kt
@@ -1,0 +1,5 @@
+package io.mockative
+
+interface DefaultInvocationTestSubject {
+    val type: String
+}

--- a/shared/src/commonTest/kotlin/io/mockative/DefaultInvocationsTests.kt
+++ b/shared/src/commonTest/kotlin/io/mockative/DefaultInvocationsTests.kt
@@ -1,0 +1,43 @@
+package io.mockative
+
+import kotlin.test.*
+
+class DefaultInvocationsTests {
+    @Mock
+    private val subject = mock(classOf<DefaultInvocationTestSubject>())
+
+    @Mock
+    private val otherSubject = mock(classOf<DefaultInvocationTestSubject>())
+
+    @Test
+    fun whenCheckingEqualityWithOtherInstance_thenResultIsFalse() {
+        @Suppress("ReplaceCallWithBinaryOperator")
+        assertFalse(subject.equals(otherSubject))
+    }
+
+    @Test
+    fun whenCheckingEqualityWithSameInstance_thenResultIsTrue() {
+        @Suppress("ReplaceCallWithBinaryOperator")
+        assertTrue(subject.equals(subject))
+    }
+
+    @Test
+    fun hashCodeIsNotEqualToHashCodeOfOtherInstance() {
+        assertNotEquals(subject.hashCode(), otherSubject.hashCode())
+    }
+
+    @Test
+    fun hashCodeIsEqualToHashCodeOfSameInstance() {
+        assertEquals(subject.hashCode(), subject.hashCode())
+    }
+
+    @Test
+    fun toStringIsNotEqualToToStringOfOtherInstance() {
+        assertNotEquals(subject.toString(), otherSubject.toString())
+    }
+
+    @Test
+    fun toStringIsEqualToToStringOfSameInstance() {
+        assertEquals(subject.toString(), subject.toString())
+    }
+}


### PR DESCRIPTION
### What's Changed

- Addresses #42 by removing generation of `equals()`, `hashCode()` and `toString()`, while providing manual implementations in `Mockable`, which invokes their `super` when not explicitly mocked.