### PR TITLE
fix: make `wasInvoked` default parameters match its expected behaviour (#62)

### DIFF
--- a/mockative/src/commonMain/kotlin/io/mockative/Verification.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/Verification.kt
@@ -15,16 +15,16 @@ val Int.time: Times
     get() = Times(this)
 
 class Verification(private val receiver: Mockable, private val expectation: Expectation) {
-    fun wasInvoked(atLeast: Times = once, atMost: Times? = null) {
-        receiver.verify(RangeVerifier(expectation, atLeast.value, atMost?.value))
+    fun wasInvoked() {
+        receiver.verify(RangeVerifier(expectation, atLeast = 1, atMost = null))
+    }
+
+    fun wasInvoked(atLeast: Times? = null, atMost: Times? = null) {
+        receiver.verify(RangeVerifier(expectation, atLeast?.value, atMost?.value))
     }
 
     fun wasInvoked(exactly: Times) {
         receiver.verify(ExactVerifier(expectation, exactly.value))
-    }
-
-    fun wasMaybeInvoked(atMost: Times) {
-        receiver.verify(RangeVerifier(expectation, null, atMost.value))
     }
 
     fun wasNotInvoked() {

--- a/mockative/src/commonMain/kotlin/io/mockative/Verification.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/Verification.kt
@@ -15,12 +15,16 @@ val Int.time: Times
     get() = Times(this)
 
 class Verification(private val receiver: Mockable, private val expectation: Expectation) {
-    fun wasInvoked(atLeast: Times? = null, atMost: Times? = null) {
-        receiver.verify(RangeVerifier(expectation, atLeast?.value, atMost?.value))
+    fun wasInvoked(atLeast: Times = once, atMost: Times? = null) {
+        receiver.verify(RangeVerifier(expectation, atLeast.value, atMost?.value))
     }
 
     fun wasInvoked(exactly: Times) {
         receiver.verify(ExactVerifier(expectation, exactly.value))
+    }
+
+    fun wasMaybeInvoked(atMost: Times) {
+        receiver.verify(RangeVerifier(expectation, null, atMost.value))
     }
 
     fun wasNotInvoked() {


### PR DESCRIPTION
As described in #62.

Given myMock.foo() is not called. The verification below succeeds:

```kotlin
verify(myMock)
    .function(myMock::foo)
    .wasInvoked()
```

### Solution

`wasInvoked` is named in a way that gives the allusion the function being verified _was_ — in fact —  _invoked_. This is the complete oposite of `wasNotInvoked`.

Changing the default `atLeast` parameter of `wasInvoked` to `once` makes a lot of sense to me.

Also, `wasInvoked(atMost = 10.times)` sounds like it _was invoked_ at least one time, and at most ten times.

### Possibly breaking changes?

I understand this can be a breaking change, when considering that some projects might be using `.wasInvoked(atMost = 10.times)` expecting `atLeast = null/0` by default. But using `0` on a `wasInvoked` function is a bit contradictory.

For that, I suggest `wasMaybeInvoked(atMost = times)`. If this is seen as overkill, I'm happy to remove it and leave the `atLeast` value as defaulting to `once`. 
This makes mandatory invoking something like `wasInvoked(atLeast = 0.times, atMost = 10.times)` for example.

From my point of view, this is more like a bug fix than a breaking change. As I genuinely see `atLeast = 0.times` as the exception, even when only `atMost` is used.