### PR TITLE
Downgrade the minimal JDK version requirement for Gradle to JDK8, and add wasmWasi target

### DIFF
--- a/buildSrc/src/main/kotlin/convention.multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/convention.multiplatform.gradle.kts
@@ -37,10 +37,15 @@ kotlin {
     mingwX64()
 
     @OptIn(ExperimentalWasmDsl::class)
-    wasm {
+    wasmJs {
         browser()
         nodejs()
         generateTypeScriptDefinitions()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmWasi {
+        nodejs()
     }
 
     @Suppress("UNUSED_VARIABLE")
@@ -101,6 +106,8 @@ kotlin {
         val mingwX64Main by getting { dependsOn(mingwMain) }
 
         // wasm
-        val wasmJsMain by getting { dependsOn(commonMain) }
+        val wasmMain by creating { dependsOn(commonMain) }
+        val wasmJsMain by getting { dependsOn(wasmMain) }
+        val wasmWasiMain by getting { dependsOn(wasmMain) }
     }
 }

--- a/mockative-code-generator/build.gradle.kts
+++ b/mockative-code-generator/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     application
 }
 
+kotlin {
+    jvmToolchain(8)
+}
+
 application {
     mainClass.set("io.mockative.generator.MainKt")
 }

--- a/mockative-processor/build.gradle.kts
+++ b/mockative-processor/build.gradle.kts
@@ -8,6 +8,7 @@ version = findProperty("project.version") as String
 
 kotlin {
     jvm()
+    jvmToolchain(8)
 
     sourceSets {
         named("jvmMain") {


### PR DESCRIPTION
Currently, the KSP processor was compiled into bytecode version 61.0, which requires the project's Gradle runs on JDK 17 or above. If not, the ksp tasks will fail with the following error message:

> java.lang.UnsupportedClassVersionError: io/mockative/MockativeSymbolProcessorProvider has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0

This can be solved by specify the `kotlin.jvmToolchain` to 8 in **mockative-processor**'s build.gradle.kts. (same to #70)

By the way, wasm target is deprecated and leads to GitHub actions failed, so I added the wasmJs and wasmWasi targets instead of the old wasm target.