### PR TITLE
fix: prevent wrapping mid-statement when generating mock functions

### DIFF
--- a/mockative-processor/src/main/kotlin/io/mockative/kotlinpoet/ProcessableType.KotlinPoet.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/kotlinpoet/ProcessableType.KotlinPoet.kt
@@ -33,7 +33,7 @@ internal fun ProcessableType.buildMockFunSpec(): FunSpec {
         .addTypeVariables(functionTypeVariables)
         .addParameter(type)
         .returns(parameterizedSourceClassName)
-        .addStatement("return %M(%T()) { stubsUnitByDefault = %L }", CONFIGURE, parameterizedMockClassName, stubsUnitByDefault)
+        .addStatement("return %M(%T()) { stubsUnitByDefault·=·%L }", CONFIGURE, parameterizedMockClassName, stubsUnitByDefault)
         .addOriginatingKSFiles(usages)
         .build()
 }


### PR DESCRIPTION
Fixes:
- #88 

Not sure how to test it, as I believe there aren't tests for the code-generation part itself, just for the whole integrated project in the `shared` module.

As per [KotlinPoet's documentation](https://square.github.io/kotlinpoet/1.x/kotlinpoet/kotlinpoet/com.squareup.kotlinpoet/-code-block/index.html), it will try to wrap lines at 100 chars. When generating mock functions for interfaces that have a 27-char long name, like `NotificationTokenRepository`, it will wrap the line after `stubUnitsByDefault` and bring the equals sign to the line below it.

Using `·` instead of space will tell KotlinPoet to _not_ wrap that space.

I tested locally by doing this:

```kotlin
class WrappingCodeGenerationTests {

    /**
     * Interfaces with a 27-long character can cause unintentional wrapping when generating code
     */
    @Mock
    val aMock = configure(mock(classOf<InterfaceWithANameThatWraps>())) {
        stubsUnitByDefault = true
    }

    @Test
    fun wrappingCodeGenerationTest() {
        aMock.hello()
    }
}
```