### PR TITLE
Aligning syntax with MockK's

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,6 @@ fun afterEach() {
   verifyNoUnverifiedExpectations(githubApi)
   
   // Verifies that the mock has no expectations that weren't invoked at least once.
-  verifyNoUnmetExpectations(s3Client)
+  checkUnnecessaryStub(s3Client)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Then, to stub a function or property on the mock there is a couple of options:
 ### Stubbing using values
 
 To begin stubbing a function you may simply pass the values to the function call inside a block 
-passed to the `every` or `coEvery` (when stubbing a `suspend` function) functions:
+passed to the `every`/`justRun` or `coEvery`/`coJustRun` (when stubbing a `suspend` function) functions:
 
 ```kotlin
 // Stub a blocking function
@@ -152,9 +152,8 @@ coEvery { repositoryMapper.mapResponseToRepository(response) }
 every { repository.maintainer }
     .returns("Nillerr")
 
-// Stub a property setter (these are stubbed by default)
-every { repository.stars = repository.stars + 1 }
-    .doesNothing()
+// Stub a property setter (functions returning `Unit` are stubbed by default)
+justRun { repository.stars = repository.stars + 1 }
 ```
 
 ### Stubbing using matchers
@@ -229,13 +228,6 @@ The following functions are available to provide a stub implementation for every
 | `returnsMany(vararg value: R)`                        | Returns the specified values in sequence. Once the last value in the sequence has been returned, this stubbing will no longer match any invocation.                                                                              |
 | `throws(throwable: Throwable)`                        | Throws the specified exception.                                                                                                                                                                                                  |
 | `throwsMany(throwable: Throwable)`                    | Throws the specified exceptions in sequence. Once the last exception in the sequence has been thrown, this stubbing will no longer match any invocation.                                                                         |
-
-When the return type of the function or property being stubbed is `Unit`, the following additional
-then function is available:
-
-| Function        | Description     |
-|-----------------|-----------------|
-| `doesNothing()` | Returns `Unit`. |
 
 ### Implicit stubbing of functions returning Unit
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ usually in the `@AfterEach` function of your tests:
 @AfterEach
 fun afterEach() {
   // Verifies that all expectations were verified through a call to `verify`.
-  verifyNoUnverifiedExpectations(githubApi)
+  confirmVerified(githubApi)
   
   // Verifies that the mock has no expectations that weren't invoked at least once.
   checkUnnecessaryStub(s3Client)

--- a/README.md
+++ b/README.md
@@ -207,7 +207,6 @@ s3Client.getObject(request, block::invoke)
 
 // Verify the call to the mock function
 verify { block.invoke(response) }
-    .wasInvoked(exactly = once)
 ```
 
 ### Stubbing implementations
@@ -289,28 +288,23 @@ using either values or matchers as per the stubbing (`every`) API:
 
 ```kotlin
 // Verify a `suspend` function (notice the use of `coVerify`)
-coVerify { githubApi.getRepository("mockative/mockative") }
-    .wasNotInvoked()
+coVerify(exactly = never) { githubApi.getRepository("mockative/mockative") }
 
 // Verify a blocking function
-verify { repositoryMapper.mapResponseToRepository(response) }
-    .wasInvoked(atLeast = 1)
+verify(atLeast = 1) { repositoryMapper.mapResponseToRepository(response) }
 
 // Verify a property getter
-verify { repository.maintainer }
-    .wasInvoked(atLeast = once, atMost = 6)
+verify(atLeast = once, atMost = 6) { repository.maintainer }
 
 // Verify a property setter
-verify { repository.stars = repository.stars + 1 }
-    .wasInvoked(exactly = 1)
+verify(exactly = 1) { repository.stars = repository.stars + 1 }
 ```
 
 ### Verification using matchers
 
 ```kotlin
 // Verify a suspend function (notice the use of `coVerify`)
-coVerify { s3Client.getObject<File>(eq(request), any()) }
-    .wasInvoked(exactly = once)
+coVerify(exactly = once) { s3Client.getObject<File>(eq(request), any()) }
 ```
 
 ## Validation
@@ -323,7 +317,7 @@ usually in the `@AfterEach` function of your tests:
 ```kotlin
 @AfterEach
 fun afterEach() {
-  // Verifies that all expectations were verified through a call to `verify { ... }.wasInvoked()`.
+  // Verifies that all expectations were verified through a call to `verify`.
   verifyNoUnverifiedExpectations(githubApi)
   
   // Verifies that the mock has no expectations that weren't invoked at least once.

--- a/README.md
+++ b/README.md
@@ -141,16 +141,13 @@ passed to the `every`/`justRun` or `coEvery`/`coJustRun` (when stubbing a `suspe
 
 ```kotlin
 // Stub a blocking function
-every { githubApi.getRepository("mockative/mockative") }
-    .invokes { response }
+every { githubApi.getRepository("mockative/mockative") } invokes { response }
 
 // Stub a `suspend` function (notice the use of `coEvery`)
-coEvery { repositoryMapper.mapResponseToRepository(response) }
-    .invokes { repository }
+coEvery { repositoryMapper.mapResponseToRepository(response) } invokes { repository }
 
 // Stub a property getter
-every { repository.maintainer }
-    .returns("Nillerr")
+every { repository.maintainer } returns "Nillerr"
 
 // Stub a property setter (functions returning `Unit` are stubbed by default)
 justRun { repository.stars = repository.stars + 1 }
@@ -203,8 +200,7 @@ pass as a mock to other functions in order to stub and verify invocations on it:
 val block = mock(classOf<Fun1<GetObjectResponse, File>>())
 
 // Stub the mock function
-every { block.invoke(response) }
-  .returns(file)
+every { block.invoke(response) } returns file
 
 // Call something that calls the mock function
 s3Client.getObject(request, block::invoke)

--- a/mockative/src/commonMain/kotlin/io/mockative/AnyResultBuilder.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/AnyResultBuilder.kt
@@ -13,5 +13,3 @@ interface AnyResultBuilder<R> {
 
     fun throwsMany(vararg throwables: Throwable) = invokesMany(*throwables.map { { throw it } }.toTypedArray())
 }
-
-fun AnyResultBuilder<Unit>.doesNothing() = invokes { }

--- a/mockative/src/commonMain/kotlin/io/mockative/AnyResultBuilder.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/AnyResultBuilder.kt
@@ -1,15 +1,15 @@
 package io.mockative
 
 interface AnyResultBuilder<R> {
-    fun invokes(block: () -> R)
+    infix fun invokes(block: () -> R)
 
     fun invokesMany(vararg blocks: () -> R)
 
-    fun returns(value: R) = invokes { value }
+    infix fun returns(value: R) = invokes { value }
 
     fun returnsMany(vararg values: R) = invokesMany(*values.map { { it } }.toTypedArray())
 
-    fun throws(throwable: Throwable) = invokes { throw throwable }
+    infix fun throws(throwable: Throwable) = invokes { throw throwable }
 
     fun throwsMany(vararg throwables: Throwable) = invokesMany(*throwables.map { { throw it } }.toTypedArray())
 }

--- a/mockative/src/commonMain/kotlin/io/mockative/AnySuspendResultBuilder.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/AnySuspendResultBuilder.kt
@@ -3,15 +3,15 @@ package io.mockative
 private inline fun <R> suspendFun(crossinline block: () -> R): suspend () -> R = { block() }
 
 interface AnySuspendResultBuilder<R> {
-    fun invokes(block: suspend () -> R)
+    infix fun invokes(block: suspend () -> R)
 
     fun invokesMany(vararg blocks: suspend () -> R)
 
-    fun returns(value: R) = invokes { value }
+    infix fun returns(value: R) = invokes { value }
 
     fun returnsMany(vararg values: R) = invokesMany(*values.map { suspendFun { it } }.toTypedArray())
 
-    fun throws(throwable: Throwable) = invokes { throw throwable }
+    infix fun throws(throwable: Throwable) = invokes { throw throwable }
 
     fun throwsMany(vararg throwables: Throwable) = invokesMany(*throwables.map { suspendFun { throw it } }.toTypedArray())
 }

--- a/mockative/src/commonMain/kotlin/io/mockative/AnySuspendResultBuilder.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/AnySuspendResultBuilder.kt
@@ -15,5 +15,3 @@ interface AnySuspendResultBuilder<R> {
 
     fun throwsMany(vararg throwables: Throwable) = invokesMany(*throwables.map { suspendFun { throw it } }.toTypedArray())
 }
-
-fun AnySuspendResultBuilder<Unit>.doesNothing() = invokes { }

--- a/mockative/src/commonMain/kotlin/io/mockative/Every.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/Every.kt
@@ -16,6 +16,10 @@ fun <R> every(block: () -> R): ResultBuilder<R> {
     }
 }
 
+fun justRun(block: () -> Unit) {
+    every(block) returns Unit
+}
+
 /**
  * Executes the given block and records the invocation on any mock object created within the block.
  *
@@ -31,4 +35,8 @@ suspend fun <R> coEvery(block: suspend () -> R): SuspendResultBuilder<R> {
     } finally {
         Matchers.clear()
     }
+}
+
+suspend fun coJustRun(block: suspend () -> Unit) {
+    coEvery(block) returns Unit
 }

--- a/mockative/src/commonMain/kotlin/io/mockative/Mockable.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/Mockable.kt
@@ -130,7 +130,7 @@ class Mockable(val instance: Any) {
         }
     }
 
-    internal fun verifyNoUnmetExpectations() {
+    internal fun checkUnnecessaryStub() {
         val unusedBlockingStubs = blockingStubs.filter { it.invocations.isEmpty() }
         val unusedSuspendStubs = suspendStubs.filter { it.invocations.isEmpty() }
 

--- a/mockative/src/commonMain/kotlin/io/mockative/Verification.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/Verification.kt
@@ -1,28 +1,18 @@
 package io.mockative
 
+val never: Int = 0
 val once: Int = 1
-val twice: Int = 2
 
-val Int.times: Int
-    get() = this
-
-val Int.time: Int
-    get() = this
-
-class Verification(private val mockable: Mockable, private val expectation: Expectation) {
+internal class Verification(private val mockable: Mockable, private val expectation: Expectation) {
     fun wasInvoked() {
         mockable.verify(RangeVerifier(expectation, atLeast = 1, atMost = null))
     }
 
-    fun wasInvoked(atLeast: Int? = null, atMost: Int? = null) {
+    fun wasInvoked(atLeast: Int?, atMost: Int?) {
         mockable.verify(RangeVerifier(expectation, atLeast, atMost))
     }
 
     fun wasInvoked(exactly: Int) {
         mockable.verify(ExactVerifier(expectation, exactly))
-    }
-
-    fun wasNotInvoked() {
-        mockable.verify(ExactVerifier(expectation, 0))
     }
 }

--- a/mockative/src/commonMain/kotlin/io/mockative/VerifyThat.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/VerifyThat.kt
@@ -8,13 +8,45 @@ fun verifyNoUnmetExpectations(receiver: Any) {
     Mockable.mockable(receiver).verifyNoUnmetExpectations()
 }
 
-fun <R> verify(block: () -> R): Verification {
+fun <R> verify(block: () -> R) {
+    verification(block).wasInvoked()
+}
+
+fun <R> verify(exactly: Int, block: () -> R) {
+    verification(block).wasInvoked(exactly)
+}
+
+fun <R> verify(
+    atLeast: Int? = null,
+    atMost: Int? = null,
+    block: () -> R
+) {
+    verification(block).wasInvoked(atLeast, atMost)
+}
+
+suspend fun <R> coVerify(block: suspend () -> R) {
+    verification(block).wasInvoked()
+}
+
+suspend fun <R> coVerify(exactly: Int, block: suspend () -> R) {
+    verification(block).wasInvoked(exactly)
+}
+
+suspend fun <R> coVerify(
+    atLeast: Int? = null,
+    atMost: Int? = null,
+    block: suspend () -> R
+) {
+    verification(block).wasInvoked(atLeast, atMost)
+}
+
+private fun <R> verification(block: () -> R): Verification {
     val (mock, invocation) = Mockable.record(block)
     val expectation = invocation.toExpectation()
     return Verification(mock, expectation)
 }
 
-suspend fun <R> coVerify(block: suspend () -> R): Verification {
+private suspend fun <R> verification(block: suspend () -> R): Verification {
     val (mock, invocation) = Mockable.record(block)
     val expectation = invocation.toExpectation()
     return Verification(mock, expectation)

--- a/mockative/src/commonMain/kotlin/io/mockative/VerifyThat.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/VerifyThat.kt
@@ -1,6 +1,6 @@
 package io.mockative
 
-fun verifyNoUnverifiedExpectations(receiver: Any) {
+fun confirmVerified(receiver: Any) {
     Mockable.mockable(receiver).confirmVerified()
 }
 

--- a/mockative/src/commonMain/kotlin/io/mockative/VerifyThat.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/VerifyThat.kt
@@ -4,8 +4,8 @@ fun verifyNoUnverifiedExpectations(receiver: Any) {
     Mockable.mockable(receiver).confirmVerified()
 }
 
-fun verifyNoUnmetExpectations(receiver: Any) {
-    Mockable.mockable(receiver).verifyNoUnmetExpectations()
+fun checkUnnecessaryStub(receiver: Any) {
+    Mockable.mockable(receiver).checkUnnecessaryStub()
 }
 
 fun <R> verify(block: () -> R) {

--- a/shared/src/commonTest/kotlin/io/github/FileServiceTests.kt
+++ b/shared/src/commonTest/kotlin/io/github/FileServiceTests.kt
@@ -101,8 +101,7 @@ class FileServiceTests {
 
         val request = GetObjectRequest(id)
 
-        every { s3Client.getObjectSync<File>(eq(request), any()) }
-            .returns(expected)
+        every { s3Client.getObjectSync<File>(eq(request), any()) } returns expected
 
         // When
         val file = fileService.getFileRawSync(id, block::invoke)

--- a/shared/src/commonTest/kotlin/io/github/GitHubServiceMockTests.kt
+++ b/shared/src/commonTest/kotlin/io/github/GitHubServiceMockTests.kt
@@ -10,6 +10,7 @@ import io.mockative.eq
 import io.mockative.every
 import io.mockative.justRun
 import io.mockative.mock
+import io.mockative.never
 import io.mockative.once
 import io.mockative.verify
 import io.mockative.verifyNoUnmetExpectations
@@ -24,12 +25,6 @@ internal class GitHubServiceMockTests {
 
     @Mock
     val github: GitHubAPI = mock(classOf<GitHubAPI>())
-
-    @Mock
-    val expected: ExpectedAPI = mock(classOf<ExpectedAPI>())
-
-    @Mock
-    val nested: GitHubService.NestedAPI = mock(classOf<GitHubService.NestedAPI>())
 
     @Mock
     val configuration: GitHubConfiguration = mock(classOf<GitHubConfiguration>())
@@ -55,7 +50,6 @@ internal class GitHubServiceMockTests {
 
         // then
         coVerify { github.create(repository) }
-            .wasInvoked(atLeast = once)
     }
 
     @Test
@@ -103,8 +97,7 @@ internal class GitHubServiceMockTests {
         service.repository(id)
 
         // then
-        coVerify { github.repository(id) }
-            .wasInvoked(exactly = once)
+        coVerify(exactly = once) { github.repository(id) }
 
         verifyNoUnmetExpectations(github)
     }
@@ -123,8 +116,7 @@ internal class GitHubServiceMockTests {
         // then
         assertNotNull(actual.exceptionOrNull())
 
-        coVerify { github.repository(id) }
-            .wasInvoked(exactly = once)
+        coVerify(exactly = once) { github.repository(id) }
     }
 
     @Test
@@ -140,8 +132,7 @@ internal class GitHubServiceMockTests {
 
         assertSame(mockative, firstRepository)
 
-        coVerify { github.repository(id) }
-            .wasInvoked(exactly = once)
+        coVerify(exactly = once) { github.repository(id) }
 
         val mockito = Repository(id, "Mockito")
         coEvery { github.repository(id) }
@@ -153,8 +144,7 @@ internal class GitHubServiceMockTests {
         // Then
         assertSame(mockito, secondRepository)
 
-        coVerify { github.repository(id) }
-            .wasInvoked(exactly = once)
+        coVerify(exactly = once) { github.repository(id) }
     }
 
     @Test
@@ -181,7 +171,6 @@ internal class GitHubServiceMockTests {
 
         // Then
         verify { configuration.token = token }
-            .wasInvoked()
     }
 
     @Test
@@ -195,7 +184,11 @@ internal class GitHubServiceMockTests {
 
         // Then
         verify { configuration.token = token }
-            .wasInvoked()
+    }
+
+    @Test
+    fun testNeverCalled() = runTest {
+        coVerify(exactly = never) { github.repository(any()) }
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/io/github/GitHubServiceMockTests.kt
+++ b/shared/src/commonTest/kotlin/io/github/GitHubServiceMockTests.kt
@@ -13,7 +13,7 @@ import io.mockative.mock
 import io.mockative.never
 import io.mockative.once
 import io.mockative.verify
-import io.mockative.verifyNoUnmetExpectations
+import io.mockative.checkUnnecessaryStub
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -37,7 +37,7 @@ internal class GitHubServiceMockTests {
 
     @AfterTest
     fun validateMocks() {
-        verifyNoUnmetExpectations(github)
+        checkUnnecessaryStub(github)
     }
 
     @Test
@@ -99,7 +99,7 @@ internal class GitHubServiceMockTests {
         // then
         coVerify(exactly = once) { github.repository(id) }
 
-        verifyNoUnmetExpectations(github)
+        checkUnnecessaryStub(github)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/io/github/GitHubServiceMockTests.kt
+++ b/shared/src/commonTest/kotlin/io/github/GitHubServiceMockTests.kt
@@ -161,7 +161,7 @@ internal class GitHubServiceMockTests {
     fun getToken() {
         // Given
         val token = "the-token"
-        every { configuration.token }.returns(token)
+        every { configuration.token } returns token
 
         // When
         val result = service.getToken()

--- a/shared/src/commonTest/kotlin/io/github/GitHubServiceMockTests.kt
+++ b/shared/src/commonTest/kotlin/io/github/GitHubServiceMockTests.kt
@@ -6,9 +6,9 @@ import io.mockative.any
 import io.mockative.classOf
 import io.mockative.coEvery
 import io.mockative.coVerify
-import io.mockative.doesNothing
 import io.mockative.eq
 import io.mockative.every
+import io.mockative.justRun
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
@@ -174,7 +174,7 @@ internal class GitHubServiceMockTests {
     fun setToken() {
         // Given
         val token = "the-token"
-        every { configuration.token = token }.doesNothing()
+        justRun { configuration.token = token }
 
         // When
         service.setToken(token)
@@ -188,7 +188,7 @@ internal class GitHubServiceMockTests {
     fun setTokenWithAny() {
         // Given
         val token = "the-token"
-        every { configuration.token = any() }.doesNothing()
+        justRun { configuration.token = any() }
 
         // When
         service.setToken(token)

--- a/shared/src/commonTest/kotlin/io/github/PopulatedClassTests.kt
+++ b/shared/src/commonTest/kotlin/io/github/PopulatedClassTests.kt
@@ -24,7 +24,7 @@ class PopulatedClassTests {
     @Test
     fun givenExpectationSetup_thenExpectationIsReturned() {
         // Given
-        every { mock.greet() }.returns("This is not hello")
+        every { mock.greet() } returns "This is not hello"
 
         // When
         val result = mock.greet()
@@ -49,8 +49,8 @@ class PopulatedClassTests {
     @Test
     fun givenExpectationOnMockedConstrcutorParameter_thenExpectationIsReturned() {
         // Given
-        every { mock.class3 }.returns(class3Mock)
-        every { class3Mock.message1 }.returns("something not message1 in class3")
+        every { mock.class3 } returns class3Mock
+        every { class3Mock.message1 } returns "something not message1 in class3"
 
         // When
         val getClass2FromMockResult = mock.class3

--- a/shared/src/commonTest/kotlin/io/github/SealedInterfaceServiceTests.kt
+++ b/shared/src/commonTest/kotlin/io/github/SealedInterfaceServiceTests.kt
@@ -24,6 +24,6 @@ class SealedInterfaceServiceTests {
         sis.acceptSealedInterface(value)
 
         // Then
-        verify { sis.acceptSealedInterface(value) }.wasInvoked(exactly = once)
+        verify(exactly = once) { sis.acceptSealedInterface(value) }
     }
 }

--- a/shared/src/commonTest/kotlin/io/github/SealedInterfaceServiceTests.kt
+++ b/shared/src/commonTest/kotlin/io/github/SealedInterfaceServiceTests.kt
@@ -3,8 +3,7 @@ package io.github
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
-import io.mockative.doesNothing
-import io.mockative.every
+import io.mockative.justRun
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.verify
@@ -17,7 +16,7 @@ class SealedInterfaceServiceTests {
     @Test
     fun sealedInterfaceTest() {
         // Given
-        every { sis.acceptSealedInterface(any()) }.doesNothing()
+        justRun { sis.acceptSealedInterface(any()) }
 
         val value = SealedInterfaceImplementation("Mockative")
 


### PR DESCRIPTION
## Summary

This pull request aims to align Mockative syntax more closely with MockK's. The changes introduced here will help reduce friction for developers transitioning from MockK to Mockative.

## Proposed changes

**1. Infix notation support (backwards compatible)**

Enabled infix notation for `invokes`, `returns` and `throws`.

```kotlin
coEvery { api.getUsers() } returns users
```

**2. Expectation parameters as `verify` arguments (breaking change)**

Moved expectation parameters within `verify` arguments instead of chaining, aligning verification with MockK's approach. Also, developers can easily forget to chain `wasInvoked()` which will cause the `verify` block to be ignored.

```kotlin
verify { /* ... */ }
verify(exactly = never) { /* ... */ }
coVerify(atLeast = once) { /* ... */ }
```

**3. Replacement of `doesNothing` with `justRun` (breaking change)**

Replaced `doesNothing` with `justRun` for conciseness and to align with MockK's terminology.

```kotlin
justRun { user.deactivated = true }
```

**4. Renaming of `verifyNoUnverifiedExpectations` and `verifyNoUnmetExpectations` (breaking change)**

Renamed `verifyNoUnverifiedExpectations` to `confirmVerified` and `verifyNoUnmetExpectations` to `checkUnnecessaryStub` to align with MockK's terminology.

```kotlin
@AfterEach
fun afterEach() {
  confirmVerified(api)
  checkUnnecessaryStub(api)
}
```