### PR TITLE
fix(Android): failure when faking sealed classes

### DIFF
--- a/mockative/build.gradle.kts
+++ b/mockative/build.gradle.kts
@@ -11,6 +11,9 @@ kotlin {
         // Common
         named("commonMain") {
             kotlin.srcDirs("$buildDir/generated/mockative-code-generator")
+            dependencies {
+                implementation(kotlin("reflect"))
+            }
         }
 
         named("jvmMain") {

--- a/mockative/build.gradle.kts
+++ b/mockative/build.gradle.kts
@@ -11,13 +11,11 @@ kotlin {
         // Common
         named("commonMain") {
             kotlin.srcDirs("$buildDir/generated/mockative-code-generator")
-            dependencies {
-                implementation(kotlin("reflect"))
-            }
         }
 
         named("jvmMain") {
             dependencies {
+                implementation(kotlin("reflect"))
                 implementation("org.objenesis:objenesis:3.3")
                 implementation("org.javassist:javassist:3.29.2-GA")
             }

--- a/mockative/src/jvmMain/kotlin/io/mockative/fake/ValueOf.kt
+++ b/mockative/src/jvmMain/kotlin/io/mockative/fake/ValueOf.kt
@@ -11,19 +11,12 @@ import kotlin.reflect.KClass
 
 private val objenesis = ObjenesisStd()
 
-@Suppress("UNCHECKED_CAST")
-private fun <T> Any.invoke(methodName: String, defaultValue: T): T {
-    val method =
-        this::class.java.methods.firstOrNull { it.name == methodName } ?: return defaultValue
-    return method.invoke(this) as T
-}
-
 private fun isSealed(clazz: Class<*>): Boolean {
-    return clazz.invoke("isSealed", false)
+    return clazz.kotlin.isSealed
 }
 
-private fun getPermittedSubclasses(clazz: Class<*>): kotlin.Array<Class<*>> {
-    return clazz.invoke("getPermittedSubclasses", emptyArray())
+private fun getPermittedSubclasses(clazz: Class<*>): List<Class<*>> {
+    return clazz.kotlin.sealedSubclasses.map { it.java }
 }
 
 @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
Fixes:
- #87

### Issue

When running Android Instrumented tests with parameters that are sealed classes on Android or in older JVMs, a NullPointerException is thrown.

### How to reproduce

1. Run an Android emulator or connect a physical Android device
2. `./gradlew :shared:connectedDebugAndroidTest`

### Cause

When running on Android or in older JVMs, the JVM functions [`Class$isSealed` and `Class$getPermittedSubclasses`](https://github.com/mockative/mockative/blob/76853d4c2a69d8c707dfd6cfdb65ea21e0922d14/mockative/src/jvmMain/kotlin/io/mockative/fake/ValueOf.kt#L38) do not exist, so the sealed class will fall onto the [`abstract` case in `makeValueOf`](https://github.com/mockative/mockative/blob/76853d4c2a69d8c707dfd6cfdb65ea21e0922d14/mockative/src/jvmMain/kotlin/io/mockative/fake/ValueOf.kt#L46C9-L46C44).

### Solution

Use Kotlin Reflect to read the Kotlin metadata from the class instead of trying to just use these functions that may not exist during runtime.

----

#### Known issue

While investigating this, I also noticed that the test `ValueOfTests.makeValueOfReturnsOtherStuff` fails when trying to get `valueOf<AbstractParameter>()`. I've created #91 to handle the abstract class case.