### PR TITLE
Allow infix notation on `invokes`, `returns` and `throws`

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,11 @@ The following functions are available to provide a stub implementation for every
 | `throws(throwable: Throwable)`                        | Throws the specified exception.                                                                                                                                                                                                  |
 | `throwsMany(throwable: Throwable)`                    | Throws the specified exceptions in sequence. Once the last exception in the sequence has been thrown, this stubbing will no longer match any invocation.                                                                         |
 
+Mockative supports infix notation for `invokes`, `returns`, and `throws` functions:
+```kotlin
+every { api.getUsers() } returns users
+```
+
 When the return type of the function or property being stubbed is `Unit`, the following additional
 then function is available:
 

--- a/mockative/src/commonMain/kotlin/io/mockative/ResultBuilder.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/ResultBuilder.kt
@@ -4,7 +4,7 @@ class ResultBuilder<R>(
     private val mock: Mockable,
     private val expectation: Expectation
 ) {
-    fun invokes(block: (arguments: Array<Any?>) -> R) {
+    infix fun invokes(block: (arguments: Array<Any?>) -> R) {
         mock.addBlockingStub(OpenBlockingStub(expectation, block))
     }
 
@@ -14,11 +14,11 @@ class ResultBuilder<R>(
 
     fun invokesMany(vararg blocks: () -> R) = invokesMany(blocks.map { block -> { _ -> block() } })
 
-    fun returns(value: R) = invokes { value }
+    infix fun returns(value: R) = invokes { value }
 
     fun returnsMany(vararg values: R) = invokesMany(values.map { value -> { value } })
 
-    fun throws(throwable: Throwable) = invokes { throw throwable }
+    infix fun throws(throwable: Throwable) = invokes { throw throwable }
 
     fun throwsMany(vararg throwables: Throwable) = invokesMany(throwables.map { throwable -> { throw throwable } })
 }

--- a/mockative/src/commonMain/kotlin/io/mockative/SuspendResultBuilder.kt
+++ b/mockative/src/commonMain/kotlin/io/mockative/SuspendResultBuilder.kt
@@ -4,7 +4,7 @@ class SuspendResultBuilder<R>(
     private val mock: Mockable,
     private val expectation: Expectation
 ) {
-    fun invokes(block: suspend (arguments: Array<Any?>) -> R) {
+    infix fun invokes(block: suspend (arguments: Array<Any?>) -> R) {
         mock.addSuspendStub(OpenSuspendStub(expectation, block))
     }
 
@@ -14,11 +14,11 @@ class SuspendResultBuilder<R>(
 
     fun invokesMany(vararg blocks: suspend () -> R) = invokesMany(blocks.map { block -> { _ -> block() } })
 
-    fun returns(value: R) = invokes { value }
+    infix fun returns(value: R) = invokes { value }
 
     fun returnsMany(vararg values: R) = invokesMany(values.map { value -> { value } })
 
-    fun throws(throwable: Throwable) = invokes { throw throwable }
+    infix fun throws(throwable: Throwable) = invokes { throw throwable }
 
     fun throwsMany(vararg throwables: Throwable) = invokesMany(throwables.map { throwable -> { throw throwable } })
 }

--- a/shared/src/commonTest/kotlin/io/github/GitHubServiceMockTests.kt
+++ b/shared/src/commonTest/kotlin/io/github/GitHubServiceMockTests.kt
@@ -180,7 +180,7 @@ internal class GitHubServiceMockTests {
     fun getToken() {
         // Given
         val token = "the-token"
-        every { configuration.token }.returns(token)
+        every { configuration.token } returns token
 
         // When
         val result = service.getToken()


### PR DESCRIPTION
cf. https://github.com/mockative/mockative/pull/90