### PR TITLE
test: add test for class with nested properties

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/ClassWithNestedProperties.kt
+++ b/shared/src/commonMain/kotlin/io/github/ClassWithNestedProperties.kt
@@ -1,0 +1,21 @@
+package io.github
+
+@Mockable
+class ClassWithNestedProperties(
+    private val prop: Level1
+)
+
+@Mockable
+class Level1(
+    private val prop: Level2
+)
+
+@Mockable
+class Level2(
+    private val prop: Level3
+)
+
+@Mockable
+class Level3(
+    private val prop: Int
+)

--- a/shared/src/commonTest/kotlin/io/github/ClassWithNestedPropertiesTests.kt
+++ b/shared/src/commonTest/kotlin/io/github/ClassWithNestedPropertiesTests.kt
@@ -1,0 +1,18 @@
+package io.github
+
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.isMock
+import io.mockative.mock
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ClassWithNestedPropertiesTests {
+    @Mock
+    val mock: ClassWithNestedProperties = mock(classOf<ClassWithNestedProperties>())
+
+    @Test
+    fun isMockEmptyClass() {
+        assertTrue(isMock(mock))
+    }
+}


### PR DESCRIPTION
This test currently fails to compile with the following error:
> Task :shared:compileTestKotlinJvm FAILED
e: file:///<...>/mockative/shared/build/generated/ksp/jvm/jvmTest/kotlin/io/github/Level1Mock.kt:22:12 Unresolved reference: Level2Mock

No mock class is generated for a mockable classes that is not used directly as a mock but indirectly as a property of another mockable class that in turn is used as a property of the mocked class. This leads to the compiler error 'Unresolved reference'.

The issue was likely introduced with 1241ddf5ec3896ac14918bec4b2962d1f9ca9028 removing the recursion in List<ProcessableType>.flatten().

See #110