### PR TITLE
feat(processor): fallback to internal constructor if no public constructor is available

### DIFF
--- a/mockative-processor/src/main/kotlin/io/mockative/ProcessableType.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/ProcessableType.kt
@@ -2,6 +2,7 @@ package io.mockative
 
 import com.google.devtools.ksp.getConstructors
 import com.google.devtools.ksp.isConstructor
+import com.google.devtools.ksp.isInternal
 import com.google.devtools.ksp.isPublic
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
@@ -35,7 +36,8 @@ data class ProcessableType(
         }
 
         private fun KSClassDeclaration.getPublicConstructor(): KSFunctionDeclaration? {
-            return getConstructors().firstOrNull { it.isPublic() }
+            val constructors = getConstructors()
+            return constructors.firstOrNull { it.isPublic() } ?: constructors.firstOrNull { it.isInternal() }
         }
 
         private fun processConstructorParameters(

--- a/shared/src/commonMain/kotlin/io/github/ClassWithInternalConstructor.kt
+++ b/shared/src/commonMain/kotlin/io/github/ClassWithInternalConstructor.kt
@@ -1,0 +1,10 @@
+package io.github
+
+@Mockable
+internal class ClassWithInternalConstructor {
+    val text: String
+
+    internal constructor(text: String) {
+        this.text = text
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/InternalConstructorTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/InternalConstructorTest.kt
@@ -1,0 +1,18 @@
+package io.github
+
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.isMock
+import io.mockative.mock
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+internal class InternalConstructorTest {
+    @Mock
+    internal val mock: ClassWithInternalConstructor = mock(classOf<ClassWithInternalConstructor>())
+
+    @Test
+    fun isMockClassWithInternalConstructor() {
+        assertTrue(isMock(mock))
+    }
+}


### PR DESCRIPTION
Fallback to internal constructor if no public constructor is available. Add a test that verifies mocking a class with only an internal constructor works.

Part of #115