### PR TITLE
Support mocking deprecated types and members

### DIFF
--- a/mockative-processor/src/main/kotlin/io/mockative/MockativeSymbolProcessor.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/MockativeSymbolProcessor.kt
@@ -4,6 +4,7 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.ksp.writeTo
 import io.mockative.kotlinpoet.buildMockFunSpecs
@@ -42,8 +43,14 @@ class MockativeSymbolProcessor(
                 val reflectionName = type.sourceClassName.reflectionName()
                 val fileName = "${reflectionName}.Mockative"
 
+                val suppressDeprecation = AnnotationSpec.builder(SUPPRESS_ANNOTATION)
+                    .addMember("%S", "DEPRECATION")
+                    .addMember("%S", "DEPRECATION_ERROR")
+                    .build()
+
                 FileSpec.builder("io.mockative", fileName)
                     .addFunctions(type.buildMockFunSpecs())
+                    .addAnnotation(suppressDeprecation)
                     .build()
                     .writeTo(codeGenerator, aggregating = false)
             }

--- a/mockative-processor/src/main/kotlin/io/mockative/ProcessableFunction.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/ProcessableFunction.kt
@@ -16,7 +16,7 @@ data class ProcessableFunction(
     val name: String,
     val returnType: TypeName,
     val isSuspend: Boolean,
-	val deprecatedAnnotation: KSAnnotation?,
+    val deprecatedAnnotation: KSAnnotation?,
     val typeVariables: List<TypeVariableName>,
     val typeParameterResolver: TypeParameterResolver,
     val isFromAny: Boolean,
@@ -37,7 +37,7 @@ data class ProcessableFunction(
                 name = declaration.simpleName.asString(),
                 returnType = declaration.returnType!!.toTypeNameMockative(typeParameterResolver),
                 isSuspend = declaration.modifiers.contains(Modifier.SUSPEND),
-				deprecatedAnnotation = declaration.annotations.firstOrNull { it.shortName.asString() == DEPRECATED_ANNOTATION.simpleName },
+                deprecatedAnnotation = declaration.annotations.firstOrNull { it.shortName.asString() == DEPRECATED_ANNOTATION.simpleName },
                 typeVariables = declaration.typeParameters
                     .map { it.toTypeVariableName(typeParameterResolver) },
                 typeParameterResolver = typeParameterResolver,

--- a/mockative-processor/src/main/kotlin/io/mockative/ProcessableFunction.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/ProcessableFunction.kt
@@ -1,5 +1,6 @@
 package io.mockative
 
+import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.kotlinpoet.TypeName
@@ -15,6 +16,7 @@ data class ProcessableFunction(
     val name: String,
     val returnType: TypeName,
     val isSuspend: Boolean,
+	val deprecatedAnnotation: KSAnnotation?,
     val typeVariables: List<TypeVariableName>,
     val typeParameterResolver: TypeParameterResolver,
     val isFromAny: Boolean,
@@ -35,6 +37,7 @@ data class ProcessableFunction(
                 name = declaration.simpleName.asString(),
                 returnType = declaration.returnType!!.toTypeNameMockative(typeParameterResolver),
                 isSuspend = declaration.modifiers.contains(Modifier.SUSPEND),
+				deprecatedAnnotation = declaration.annotations.firstOrNull { it.shortName.asString() == DEPRECATED_ANNOTATION.simpleName },
                 typeVariables = declaration.typeParameters
                     .map { it.toTypeVariableName(typeParameterResolver) },
                 typeParameterResolver = typeParameterResolver,

--- a/mockative-processor/src/main/kotlin/io/mockative/ProcessableProperty.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/ProcessableProperty.kt
@@ -1,5 +1,6 @@
 package io.mockative
 
+import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.ksp.TypeParameterResolver
@@ -12,6 +13,7 @@ data class ProcessableProperty(
     val type: TypeName,
     val typeParameterResolver: TypeParameterResolver,
     val receiver: TypeName?,
+    val deprecatedAnnotation: KSAnnotation?
 ) {
     companion object {
         fun fromDeclaration(
@@ -27,6 +29,7 @@ data class ProcessableProperty(
                 type = declaration.type.toTypeNameMockative(typeParameterResolver),
                 typeParameterResolver = typeParameterResolver,
                 receiver = declaration.extensionReceiver?.toTypeNameMockative(typeParameterResolver),
+                deprecatedAnnotation = declaration.annotations.firstOrNull { it.shortName.asString() == DEPRECATED_ANNOTATION.simpleName }
             )
         }
     }

--- a/mockative-processor/src/main/kotlin/io/mockative/TypeNames.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/TypeNames.kt
@@ -11,6 +11,7 @@ val KCLASS = ClassName("kotlin.reflect", "KClass")
 val MOCK_ANNOTATION = Mock::class.asClassName()
 val SUPPRESS_ANNOTATION = Suppress::class.asClassName()
 val OPT_IN = ClassName("kotlin", "OptIn")
+val DEPRECATED_ANNOTATION = Deprecated::class.asClassName()
 
 val MOCKABLE = Mockable::class.asClassName()
 

--- a/mockative-processor/src/main/kotlin/io/mockative/kotlinpoet/ProcessableFunction.KotlinPoet.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/kotlinpoet/ProcessableFunction.KotlinPoet.kt
@@ -1,6 +1,7 @@
 package io.mockative.kotlinpoet
 
 import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import io.mockative.*
 
 internal fun ProcessableFunction.buildFunSpec(): FunSpec {
@@ -17,6 +18,10 @@ internal fun ProcessableFunction.buildFunSpec(): FunSpec {
 
     if (receiver != null) {
         builder.receiver(receiver)
+    }
+
+    if (deprecatedAnnotation != null) {
+        builder.addAnnotation(deprecatedAnnotation.toAnnotationSpec())
     }
 
     builder

--- a/mockative-processor/src/main/kotlin/io/mockative/kotlinpoet/ProcessableProperty.KotlinPoet.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/kotlinpoet/ProcessableProperty.KotlinPoet.kt
@@ -1,6 +1,7 @@
 package io.mockative.kotlinpoet
 
 import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import io.mockative.INVOCATION_GETTER
 import io.mockative.INVOCATION_SETTER
 import io.mockative.MOCKABLE
@@ -13,6 +14,10 @@ internal fun ProcessableProperty.buildPropertySpec(): PropertySpec {
 
     if (receiver != null) {
         builder.receiver(receiver)
+    }
+
+    if (deprecatedAnnotation != null) {
+        builder.addAnnotation(deprecatedAnnotation.toAnnotationSpec())
     }
 
     return builder

--- a/mockative-processor/src/main/kotlin/io/mockative/kotlinpoet/ProcessableType.KotlinPoet.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/kotlinpoet/ProcessableType.KotlinPoet.kt
@@ -178,12 +178,12 @@ internal fun ProcessableType.buildMockTypeSpec(): TypeSpec {
     }
 
     val annotations = buildList {
-        // why??
-        val suppressDeprecationError = AnnotationSpec.builder(SUPPRESS_ANNOTATION)
+        val suppressDeprecation = AnnotationSpec.builder(SUPPRESS_ANNOTATION)
+            .addMember("%S", "DEPRECATION")
             .addMember("%S", "DEPRECATION_ERROR")
             .build()
 
-        add(suppressDeprecationError)
+        add(suppressDeprecation)
 
         val optInSpec = buildOptInAnnotationSpec()
         if (optInSpec != null) {

--- a/shared/src/commonMain/kotlin/io/github/deprecation/DeprecatedTypes.kt
+++ b/shared/src/commonMain/kotlin/io/github/deprecation/DeprecatedTypes.kt
@@ -1,0 +1,17 @@
+package io.github.deprecation
+
+import io.github.Mockable
+
+@Deprecated("This class is deprecated", level = DeprecationLevel.WARNING)
+@Mockable
+class DeprecatedClassWarning
+
+@Deprecated("This class is deprecated", level = DeprecationLevel.ERROR)
+@Mockable
+class DeprecatedClassError
+
+@Deprecated("This interface is deprecated", level = DeprecationLevel.WARNING)
+interface DeprecatedInterfaceWarning
+
+@Deprecated("This interface is deprecated", level = DeprecationLevel.ERROR)
+interface DeprecatedInterfaceError

--- a/shared/src/commonMain/kotlin/io/github/deprecation/TypesWithDeprecatedMembers.kt
+++ b/shared/src/commonMain/kotlin/io/github/deprecation/TypesWithDeprecatedMembers.kt
@@ -5,30 +5,30 @@ import io.github.Mockable
 @Mockable
 class ClassWithDeprecatedMembers {
 
-	@Deprecated("This property is deprecated", level = DeprecationLevel.WARNING)
-	val deprecatedPropertyWarning: String = "warning"
+    @Deprecated("This property is deprecated", level = DeprecationLevel.WARNING)
+    val deprecatedPropertyWarning: String = "warning"
 
-	@Deprecated("This function is deprecated", level = DeprecationLevel.WARNING)
-	fun deprecatedFunctionWarning() {}
+    @Deprecated("This function is deprecated", level = DeprecationLevel.WARNING)
+    fun deprecatedFunctionWarning() {}
 
-	@Deprecated("This property is deprecated", level = DeprecationLevel.ERROR)
-	val deprecatedPropertyError: String = "error"
+    @Deprecated("This property is deprecated", level = DeprecationLevel.ERROR)
+    val deprecatedPropertyError: String = "error"
 
-	@Deprecated("This function is deprecated", level = DeprecationLevel.ERROR)
-	fun deprecatedFunctionError() {}
+    @Deprecated("This function is deprecated", level = DeprecationLevel.ERROR)
+    fun deprecatedFunctionError() {}
 }
 
 interface InterfaceWithDeprecatedMembers {
 
-	@Deprecated("This property is deprecated", level = DeprecationLevel.WARNING)
-	val deprecatedPropertyWarning: String
+    @Deprecated("This property is deprecated", level = DeprecationLevel.WARNING)
+    val deprecatedPropertyWarning: String
 
-	@Deprecated("This function is deprecated", level = DeprecationLevel.WARNING)
-	fun deprecatedFunctionWarning()
+    @Deprecated("This function is deprecated", level = DeprecationLevel.WARNING)
+    fun deprecatedFunctionWarning()
 
-	@Deprecated("This property is deprecated", level = DeprecationLevel.ERROR)
-	val deprecatedPropertyError: String
+    @Deprecated("This property is deprecated", level = DeprecationLevel.ERROR)
+    val deprecatedPropertyError: String
 
-	@Deprecated("This function is deprecated", level = DeprecationLevel.ERROR)
-	fun deprecatedFunctionError()
+    @Deprecated("This function is deprecated", level = DeprecationLevel.ERROR)
+    fun deprecatedFunctionError()
 }

--- a/shared/src/commonMain/kotlin/io/github/deprecation/TypesWithDeprecatedMembers.kt
+++ b/shared/src/commonMain/kotlin/io/github/deprecation/TypesWithDeprecatedMembers.kt
@@ -1,0 +1,34 @@
+package io.github.deprecation
+
+import io.github.Mockable
+
+@Mockable
+class ClassWithDeprecatedMembers {
+
+	@Deprecated("This property is deprecated", level = DeprecationLevel.WARNING)
+	val deprecatedPropertyWarning: String = "warning"
+
+	@Deprecated("This function is deprecated", level = DeprecationLevel.WARNING)
+	fun deprecatedFunctionWarning() {}
+
+	@Deprecated("This property is deprecated", level = DeprecationLevel.ERROR)
+	val deprecatedPropertyError: String = "error"
+
+	@Deprecated("This function is deprecated", level = DeprecationLevel.ERROR)
+	fun deprecatedFunctionError() {}
+}
+
+interface InterfaceWithDeprecatedMembers {
+
+	@Deprecated("This property is deprecated", level = DeprecationLevel.WARNING)
+	val deprecatedPropertyWarning: String
+
+	@Deprecated("This function is deprecated", level = DeprecationLevel.WARNING)
+	fun deprecatedFunctionWarning()
+
+	@Deprecated("This property is deprecated", level = DeprecationLevel.ERROR)
+	val deprecatedPropertyError: String
+
+	@Deprecated("This function is deprecated", level = DeprecationLevel.ERROR)
+	fun deprecatedFunctionError()
+}

--- a/shared/src/commonTest/kotlin/io/github/deprecation/DeprecatedMembersTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/deprecation/DeprecatedMembersTest.kt
@@ -9,19 +9,19 @@ import kotlin.test.assertTrue
 
 class DeprecatedMembersTest {
 
-	@Mock
-	private val classWithDeprecatedMembers = mock(classOf<ClassWithDeprecatedMembers>())
+    @Mock
+    private val classWithDeprecatedMembers = mock(classOf<ClassWithDeprecatedMembers>())
 
-	@Mock
-	private val interfaceWithDeprecatedMembers = mock(classOf<InterfaceWithDeprecatedMembers>())
+    @Mock
+    private val interfaceWithDeprecatedMembers = mock(classOf<InterfaceWithDeprecatedMembers>())
 
-	@Test
-	fun classWithDeprecatedMembersTest() {
-		assertTrue(isMock(classWithDeprecatedMembers))
-	}
+    @Test
+    fun classWithDeprecatedMembersTest() {
+        assertTrue(isMock(classWithDeprecatedMembers))
+    }
 
-	@Test
-	fun interfaceWithDeprecatedMembersTest() {
-		assertTrue(isMock(interfaceWithDeprecatedMembers))
-	}
+    @Test
+    fun interfaceWithDeprecatedMembersTest() {
+        assertTrue(isMock(interfaceWithDeprecatedMembers))
+    }
 }

--- a/shared/src/commonTest/kotlin/io/github/deprecation/DeprecatedMembersTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/deprecation/DeprecatedMembersTest.kt
@@ -1,0 +1,27 @@
+package io.github.deprecation
+
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.isMock
+import io.mockative.mock
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class DeprecatedMembersTest {
+
+	@Mock
+	private val classWithDeprecatedMembers = mock(classOf<ClassWithDeprecatedMembers>())
+
+	@Mock
+	private val interfaceWithDeprecatedMembers = mock(classOf<InterfaceWithDeprecatedMembers>())
+
+	@Test
+	fun classWithDeprecatedMembersTest() {
+		assertTrue(isMock(classWithDeprecatedMembers))
+	}
+
+	@Test
+	fun interfaceWithDeprecatedMembersTest() {
+		assertTrue(isMock(interfaceWithDeprecatedMembers))
+	}
+}

--- a/shared/src/commonTest/kotlin/io/github/deprecation/DeprecatedTypesTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/deprecation/DeprecatedTypesTest.kt
@@ -1,0 +1,44 @@
+package io.github.deprecation
+
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.isMock
+import io.mockative.mock
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@Suppress("DEPRECATION", "DEPRECATION_ERROR")
+class DeprecatedTypesTest {
+
+	@Mock
+	private val deprecatedClassWarning = mock(classOf<DeprecatedClassWarning>())
+
+	@Mock
+	private val deprecatedClassError = mock(classOf<DeprecatedClassError>())
+
+	@Mock
+	private val deprecatedInterfaceWarning = mock(classOf<DeprecatedInterfaceWarning>())
+
+	@Mock
+	private val deprecatedInterfaceError = mock(classOf<DeprecatedInterfaceError>())
+
+	@Test
+	fun deprecatedClassWarningTest() {
+		assertTrue(isMock(deprecatedClassWarning))
+	}
+
+	@Test
+	fun deprecatedClassErrorTest() {
+		assertTrue(isMock(deprecatedClassError))
+	}
+
+	@Test
+	fun deprecatedInterfaceWarningTest() {
+		assertTrue(isMock(deprecatedInterfaceWarning))
+	}
+
+	@Test
+	fun deprecatedInterfaceErrorTest() {
+		assertTrue(isMock(deprecatedInterfaceError))
+	}
+}

--- a/shared/src/commonTest/kotlin/io/github/deprecation/DeprecatedTypesTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/deprecation/DeprecatedTypesTest.kt
@@ -10,35 +10,35 @@ import kotlin.test.assertTrue
 @Suppress("DEPRECATION", "DEPRECATION_ERROR")
 class DeprecatedTypesTest {
 
-	@Mock
-	private val deprecatedClassWarning = mock(classOf<DeprecatedClassWarning>())
+    @Mock
+    private val deprecatedClassWarning = mock(classOf<DeprecatedClassWarning>())
 
-	@Mock
-	private val deprecatedClassError = mock(classOf<DeprecatedClassError>())
+    @Mock
+    private val deprecatedClassError = mock(classOf<DeprecatedClassError>())
 
-	@Mock
-	private val deprecatedInterfaceWarning = mock(classOf<DeprecatedInterfaceWarning>())
+    @Mock
+    private val deprecatedInterfaceWarning = mock(classOf<DeprecatedInterfaceWarning>())
 
-	@Mock
-	private val deprecatedInterfaceError = mock(classOf<DeprecatedInterfaceError>())
+    @Mock
+    private val deprecatedInterfaceError = mock(classOf<DeprecatedInterfaceError>())
 
-	@Test
-	fun deprecatedClassWarningTest() {
-		assertTrue(isMock(deprecatedClassWarning))
-	}
+    @Test
+    fun deprecatedClassWarningTest() {
+        assertTrue(isMock(deprecatedClassWarning))
+    }
 
-	@Test
-	fun deprecatedClassErrorTest() {
-		assertTrue(isMock(deprecatedClassError))
-	}
+    @Test
+    fun deprecatedClassErrorTest() {
+        assertTrue(isMock(deprecatedClassError))
+    }
 
-	@Test
-	fun deprecatedInterfaceWarningTest() {
-		assertTrue(isMock(deprecatedInterfaceWarning))
-	}
+    @Test
+    fun deprecatedInterfaceWarningTest() {
+        assertTrue(isMock(deprecatedInterfaceWarning))
+    }
 
-	@Test
-	fun deprecatedInterfaceErrorTest() {
-		assertTrue(isMock(deprecatedInterfaceError))
-	}
+    @Test
+    fun deprecatedInterfaceErrorTest() {
+        assertTrue(isMock(deprecatedInterfaceError))
+    }
 }


### PR DESCRIPTION
This pull request adds support for mocking deprecated types and members for both `WARNING` and `ERROR` levels. At the moment, Mockative does not allow mocking deprecated types when marked with `ERROR` level. Also, on projects that have `allWarningsAsErrors` enabled, Mockative does not allow to mock deprecated types and members with `WARNING` level neither, as `@Deprecated` annotations are not copied on the properties and as types and members usage warnings are not ignored using `@Suppress` annotation.

Looking forward to your feedback and thoughts. Thank you!

btw: Would it be possible to have a look at #100? I just rebased the branch on main.