### PR TITLE
Fix Kotlin 2.3.20 compatibility and Native fake class generation

### DIFF
--- a/buildSrc/src/main/kotlin/convention.multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/convention.multiplatform.gradle.kts
@@ -10,9 +10,9 @@ kotlin {
 
     jvm()
 
-    androidLibrary {
+    android {
         minSdk = 21
-        compileSdk = 36
+        compileSdk = 37
         namespace = "io.mockative"
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ android.useAndroidX=true
 
 #Versioning
 project.group=io.mockative
-project.version=3.3.0
+project.version=3.3.1-SNAPSHOT
 
 #KSP
 ksp.useKSP2=true

--- a/mockative-plugin/build.gradle.kts
+++ b/mockative-plugin/build.gradle.kts
@@ -28,6 +28,21 @@ kotlin {
     jvmToolchain(11)
 }
 
+val generateVersionProperties by tasks.registering {
+    val outputDir = layout.buildDirectory.dir("generated/mockative-version")
+    val projectVersion = project.version.toString()
+    outputs.dir(outputDir)
+    doLast {
+        val file = outputDir.get().file("mockative-version.properties").asFile
+        file.parentFile.mkdirs()
+        file.writeText("version=$projectVersion\n")
+    }
+}
+
+sourceSets.main {
+    resources.srcDir(generateVersionProperties.map { it.outputs.files.singleFile })
+}
+
 val copySourcesToResources by tasks.registering(Copy::class) {
     from("$rootDir/mockative-test/src")
     into("src/main/resources/src/")

--- a/mockative-plugin/src/main/kotlin/io/mockative/MockativePlugin.kt
+++ b/mockative-plugin/src/main/kotlin/io/mockative/MockativePlugin.kt
@@ -9,7 +9,13 @@ import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import java.io.File
 
 abstract class MockativePlugin : Plugin<Project> {
-    private val version = "3.2.3"
+    private val version: String by lazy {
+        val props = java.util.Properties()
+        MockativePlugin::class.java.classLoader
+            .getResourceAsStream("mockative-version.properties")
+            ?.use { props.load(it) }
+        props.getProperty("version") ?: error("Mockative plugin version not found in mockative-version.properties")
+    }
 
     override fun apply(project: Project) {
         project.pluginManager.apply("com.google.devtools.ksp")

--- a/mockative-processor/src/main/kotlin/io/mockative/MockativeSymbolProcessor.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/MockativeSymbolProcessor.kt
@@ -85,6 +85,7 @@ class MockativeSymbolProcessor(
 
             // Generate native-specific makeValueOf (only for main source sets with @Mockable types)
             val isNative = platforms.any { it is NativePlatformInfo }
+            log.info("platforms: ${platforms.map { it.platformName }}, isNative=$isNative, processableTypes=${processableTypes.size}")
             if (isNative && !hasGeneratedNativeMakeValueOf && processableTypes.isNotEmpty()) {
                 log.info("Generating native makeValueOf for platform: ${platforms.map { it.platformName }}")
                 val generator = NativeMakeValueOfGenerator(codeGenerator, configuration, processableTypes)

--- a/mockative-processor/src/main/kotlin/io/mockative/NativeMakeValueOfGenerator.kt
+++ b/mockative-processor/src/main/kotlin/io/mockative/NativeMakeValueOfGenerator.kt
@@ -1,7 +1,5 @@
 package io.mockative
 
-import com.google.devtools.ksp.getDeclaredFunctions
-import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.isAbstract
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
@@ -23,6 +21,7 @@ import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
 
@@ -209,9 +208,26 @@ class NativeMakeValueOfGenerator(
         val declaration = fake.declaration
         val className = fake.className
         val fakeName = fakeSimpleName(className)
+        val classTypeParamResolver = declaration.typeParameters.toTypeParameterResolver()
+
+        val optInAnnotations = collectOptInAnnotations(declaration)
 
         val typeSpecBuilder = TypeSpec.classBuilder(fakeName)
             .addModifiers(KModifier.INTERNAL)
+            .addAnnotation(
+                AnnotationSpec.builder(SUPPRESS_ANNOTATION)
+                    .addMember("%S", "DEPRECATION")
+                    .addMember("%S", "OVERRIDE_DEPRECATION")
+                    .build()
+            )
+
+        if (optInAnnotations.isNotEmpty()) {
+            val optInBuilder = AnnotationSpec.builder(OPT_IN)
+            for (annotation in optInAnnotations) {
+                optInBuilder.addMember("%T::class", annotation)
+            }
+            typeSpecBuilder.addAnnotation(optInBuilder.build())
+        }
 
         if (declaration.classKind == ClassKind.INTERFACE) {
             typeSpecBuilder.addSuperinterface(className)
@@ -221,11 +237,8 @@ class NativeMakeValueOfGenerator(
             if (primaryConstructor != null && primaryConstructor.parameters.isNotEmpty()) {
                 val codeArgs = mutableListOf<Any>()
                 val formatParts = primaryConstructor.parameters.map { param ->
-                    val paramType = param.type.toTypeName()
                     codeArgs.add(valueOfMember)
-                    codeArgs.add(paramType)
-                    codeArgs.add(paramType)
-                    "%M<%T>() as %T"
+                    "%M()"
                 }
                 typeSpecBuilder.addSuperclassConstructorParameter(
                     CodeBlock.of(formatParts.joinToString(", "), *codeArgs.toTypedArray())
@@ -233,14 +246,22 @@ class NativeMakeValueOfGenerator(
             }
         }
 
-        for (func in declaration.getDeclaredFunctions()) {
+        val seenFunctions = mutableSetOf<String>()
+        val seenProperties = mutableSetOf<String>()
+
+        for (func in declaration.getAllFunctions()) {
             if (!func.isAbstract) continue
-            typeSpecBuilder.addFunction(buildFakeFunction(func))
+            val signature = buildFunctionSignature(func)
+            if (!seenFunctions.add(signature)) continue
+            val built = buildFakeFunction(func, classTypeParamResolver) ?: continue
+            typeSpecBuilder.addFunction(built)
         }
 
-        for (prop in declaration.getDeclaredProperties()) {
+        for (prop in declaration.getAllProperties()) {
             if (!prop.isAbstract()) continue
-            typeSpecBuilder.addProperty(buildFakeProperty(prop))
+            if (!seenProperties.add(prop.simpleName.asString())) continue
+            val built = buildFakeProperty(prop, classTypeParamResolver) ?: continue
+            typeSpecBuilder.addProperty(built)
         }
 
         val fileSpec = FileSpec.builder(fakePackage, fakeName)
@@ -250,14 +271,82 @@ class NativeMakeValueOfGenerator(
         fileSpec.writeTo(codeGenerator, Dependencies(aggregating = false))
     }
 
-    private fun buildFakeFunction(func: KSFunctionDeclaration): FunSpec {
+    private fun collectOptInAnnotations(declaration: KSClassDeclaration): Set<ClassName> {
+        val result = mutableSetOf<ClassName>()
+        fun collectFrom(decl: KSClassDeclaration) {
+            for (annotation in decl.annotations) {
+                val annotationType = annotation.annotationType.resolve().declaration as? KSClassDeclaration ?: continue
+                val isOptIn = annotationType.annotations.any {
+                    val name = it.annotationType.resolve().declaration.qualifiedName?.asString()
+                    name == "kotlin.RequiresOptIn" || name == "kotlin.OptIn"
+                }
+                if (isOptIn) {
+                    result.add(annotationType.toClassName())
+                }
+            }
+            for (func in decl.getAllFunctions()) {
+                for (annotation in func.annotations) {
+                    val annotationType = annotation.annotationType.resolve().declaration as? KSClassDeclaration ?: continue
+                    val isOptIn = annotationType.annotations.any {
+                        val name = it.annotationType.resolve().declaration.qualifiedName?.asString()
+                        name == "kotlin.RequiresOptIn" || name == "kotlin.OptIn"
+                    }
+                    if (isOptIn) {
+                        result.add(annotationType.toClassName())
+                    }
+                }
+            }
+            for (prop in decl.getAllProperties()) {
+                for (annotation in prop.annotations) {
+                    val annotationType = annotation.annotationType.resolve().declaration as? KSClassDeclaration ?: continue
+                    val isOptIn = annotationType.annotations.any {
+                        val name = it.annotationType.resolve().declaration.qualifiedName?.asString()
+                        name == "kotlin.RequiresOptIn" || name == "kotlin.OptIn"
+                    }
+                    if (isOptIn) {
+                        result.add(annotationType.toClassName())
+                    }
+                }
+            }
+        }
+        collectFrom(declaration)
+        return result
+    }
+
+    private fun buildFunctionSignature(func: KSFunctionDeclaration): String {
+        val name = func.simpleName.asString()
+        val params = func.parameters.joinToString(",") { p ->
+            p.type.resolve().declaration.qualifiedName?.asString() ?: "_"
+        }
+        return "$name($params)"
+    }
+
+    private fun buildFakeFunction(
+        func: KSFunctionDeclaration,
+        parentResolver: com.squareup.kotlinpoet.ksp.TypeParameterResolver,
+    ): FunSpec? {
         val name = func.simpleName.asString()
         val returnType = func.returnType?.resolve()
         val returnTypeName = returnType?.declaration?.qualifiedName?.asString() ?: "kotlin.Unit"
         val isSuspend = func.modifiers.contains(Modifier.SUSPEND)
 
+        val funcResolver = try {
+            func.typeParameters.toTypeParameterResolver(parentResolver)
+        } catch (_: Exception) {
+            return null
+        }
+
         val builder = FunSpec.builder(name)
             .addModifiers(KModifier.OVERRIDE)
+
+        for (typeParam in func.typeParameters) {
+            val bounds = typeParam.bounds.mapNotNull { bound ->
+                try { bound.toTypeName(funcResolver) } catch (_: Exception) { null }
+            }.toList()
+            builder.addTypeVariable(
+                TypeVariableName(typeParam.name.asString(), bounds)
+            )
+        }
 
         if (isSuspend) {
             builder.addModifiers(KModifier.SUSPEND)
@@ -265,43 +354,56 @@ class NativeMakeValueOfGenerator(
 
         for (param in func.parameters) {
             val paramName = param.name?.asString() ?: "_"
-            val paramType = param.type.toTypeName()
+            val paramType = try {
+                param.type.toTypeName(funcResolver)
+            } catch (_: Exception) {
+                return null
+            }
             builder.addParameter(paramName, paramType)
         }
 
         if (returnTypeName != "kotlin.Unit") {
-            val resolvedReturnType = func.returnType!!.toTypeName()
+            val resolvedReturnType = try {
+                func.returnType!!.toTypeName(funcResolver)
+            } catch (_: Exception) {
+                return null
+            }
             builder.returns(resolvedReturnType)
-            builder.addAnnotation(
-                AnnotationSpec.builder(SUPPRESS_ANNOTATION)
-                    .addMember("%S", "UNCHECKED_CAST")
-                    .build()
-            )
-            builder.addStatement(
-                "return %M<%T>() as %T",
-                valueOfMember,
-                resolvedReturnType,
-                resolvedReturnType,
-            )
         }
+
+        builder.addStatement(
+            "throw %T(%S)",
+            ClassName("kotlin", "NotImplementedError"),
+            "Mockative: Fake implementation of '${name}' should not be called. " +
+                "This is a stub used during mock creation. If you see this, " +
+                "the mock may not be configured correctly.",
+        )
 
         return builder.build()
     }
 
-    private fun buildFakeProperty(prop: KSPropertyDeclaration): PropertySpec {
+    private fun buildFakeProperty(
+        prop: KSPropertyDeclaration,
+        parentResolver: com.squareup.kotlinpoet.ksp.TypeParameterResolver,
+    ): PropertySpec? {
         val name = prop.simpleName.asString()
-        val typeName = prop.type.toTypeName()
+        val typeName = try {
+            prop.type.toTypeName(parentResolver)
+        } catch (_: Exception) {
+            return null
+        }
 
         return PropertySpec.builder(name, typeName)
             .addModifiers(KModifier.OVERRIDE)
-            .addAnnotation(
-                AnnotationSpec.builder(SUPPRESS_ANNOTATION)
-                    .addMember("%S", "UNCHECKED_CAST")
-                    .build()
-            )
             .getter(
                 FunSpec.getterBuilder()
-                    .addStatement("return %M<%T>() as %T", valueOfMember, typeName, typeName)
+                    .addStatement(
+                        "throw %T(%S)",
+                        ClassName("kotlin", "NotImplementedError"),
+                        "Mockative: Fake implementation of '${name}' should not be called. " +
+                            "This is a stub used during mock creation. If you see this, " +
+                            "the mock may not be configured correctly.",
+                    )
                     .build()
             )
             .build()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,8 +7,8 @@ pluginManagement {
     }
 
     plugins {
-        kotlin("multiplatform") version "2.3.0" apply false
-        kotlin("plugin.allopen") version "2.3.0" apply false
+        kotlin("multiplatform") version "2.3.20" apply false
+        kotlin("plugin.allopen") version "2.3.20" apply false
 
         id("com.google.devtools.ksp") version "2.3.7" apply false
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
     id("com.android.kotlin.multiplatform.library")
 
-    id("io.mockative") version "3.2.3"
+    id("io.mockative") version "3.3.1-SNAPSHOT"
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
 }
 

--- a/shared/src/commonMain/kotlin/io/github/ValueOfTestTypes.kt
+++ b/shared/src/commonMain/kotlin/io/github/ValueOfTestTypes.kt
@@ -79,3 +79,16 @@ interface ValueOfGapService {
     fun acceptNullableEnum(color: Color?)
     fun acceptNullableInterface(value: NonMockableInterface?)
 }
+
+// Interface with function-level type parameters (like CoroutineContext.get)
+interface TypeParameterizedMethods {
+    fun <T> genericFunction(value: T): T
+    fun <K, V> multiGenericFunction(key: K, value: V): Map<K, V>
+}
+
+// Service that takes TypeParameterizedMethods as a parameter,
+// forcing the processor to generate a Fake__ class for it on Native.
+@Mockable
+interface GenericMethodService {
+    fun acceptGenericMethods(handler: TypeParameterizedMethods)
+}


### PR DESCRIPTION
## Summary

- **Upgrade to Kotlin 2.3.20** with associated Gradle deprecation fixes (`androidLibrary` → `android`, compileSdk 37)
- **Fix hardcoded version bug in MockativePlugin** — the plugin had `version = "3.2.3"` hardcoded for the `mockative-processor` dependency, meaning consumers always got the old v3.2.3 processor regardless of which plugin version they used. This caused `actual makeValueOf` declarations to never be generated on Native. Replaced with dynamic version lookup from a generated properties file.
- **Rewrite NativeMakeValueOfGenerator for robustness** — the fake class generator had multiple issues that surfaced when processing real-world codebases with complex type hierarchies (Ktor, coroutines):
  - Only implemented directly declared members (`getDeclaredFunctions`), missing inherited abstract members from supertypes → switched to `getAllFunctions()`/`getAllProperties()` with deduplication
  - Crashed on function-level type parameters (e.g. `CoroutineContext.get<E>`) due to missing `TypeParameterResolver` → resolve type parameters at both class and function level
  - Did not propagate `@OptIn` annotations required by supertypes annotated with `@RequiresOptIn` (e.g. Ktor's `@InternalAPI`) → collect and apply `@OptIn` from the type hierarchy
  - Generated `valueOf<T>()` calls that failed for non-reified type parameters → replace all valueOf calls in fake members with `NotImplementedError` throws (fakes are only used during mock creation, not at runtime)
  - Simplified abstract class super constructor args to plain `valueOf()` (no type parameter, no cast needed)
  - Added `@Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")` to generated fakes

## Test plan

- [x] Mockative's own iOS tests pass (`iosSimulatorArm64Test`)
- [x] Real-world validation: nebula-mobile-app (491 tests passed, 1 unrelated failure, 1 skipped) with complex Ktor/coroutines type hierarchies
- [x] Added `TypeParameterizedMethods` and `GenericMethodService` test types to exercise function-level generic type parameters