### PR TITLE
Fix duplicate code generation with Ktorfit plugin

### DIFF
--- a/mockative-plugin/src/main/kotlin/io/mockative/MockativePlugin.kt
+++ b/mockative-plugin/src/main/kotlin/io/mockative/MockativePlugin.kt
@@ -52,7 +52,7 @@ abstract class MockativePlugin : Plugin<Project> {
 
         // Add `mockative-processor` as dependency of KSP configurations
         project.configurations.whenObjectAdded { configuration ->
-            if (configuration.name != "ksp" && configuration.name.startsWith("ksp")) {
+            if (configuration.name != "ksp" && configuration.name.startsWith("ksp") && !configuration.name.contains("Metadata")) {
                 project.dependencies.add(configuration.name, "io.mockative:mockative-processor:$version")
             }
         }


### PR DESCRIPTION
## Summary
- Fixes #153 — excludes metadata KSP configurations (e.g. `kspCommonMainMetadata`) from mockative processor registration
- When another KSP plugin like Ktorfit triggers metadata compilation, the processor was running for both the metadata and platform-specific targets, generating the same mock classes twice and causing redeclaration errors
- The fix adds a `!configuration.name.contains("Metadata")` filter in `MockativePlugin.kt` to skip metadata configurations, since Mockative generates concrete implementations (not `expect` declarations) and should only run for platform targets

## Test plan
- [ ] Verify `./gradlew :mockative-plugin:compileKotlin` passes (confirmed locally)
- [ ] Test with a project that applies both Mockative and Ktorfit plugins — confirm no redeclaration errors
- [ ] Verify mocks are still generated correctly for all platform targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)